### PR TITLE
Handle mappingproxy values in node snapshots

### DIFF
--- a/data/nodes.py
+++ b/data/nodes.py
@@ -1,4 +1,5 @@
 import json, sqlite3, time, threading
+from collections.abc import Mapping
 from dataclasses import asdict, is_dataclass
 from pathlib import Path
 from meshtastic.serial_interface import SerialInterface
@@ -22,7 +23,7 @@ def _jsonable(obj):
     """Recursively convert dataclasses and objects into JSON-serialisable types."""
     if is_dataclass(obj):
         return _jsonable(asdict(obj))
-    if isinstance(obj, dict):
+    if isinstance(obj, Mapping):
         return {k: _jsonable(v) for k, v in obj.items()}
     if isinstance(obj, (list, tuple)):
         return [_jsonable(v) for v in obj]

--- a/test/test_nodes_serialization.py
+++ b/test/test_nodes_serialization.py
@@ -43,7 +43,8 @@ def test_upsert_node_handles_position(tmp_path):
             longitude: float = 13.4
             altitude: float = 34.0
 
-        n = {"num": 7, "position": Position()}
+        extra = types.MappingProxyType({"foo": "bar"})
+        n = {"num": 7, "position": Position(), "extra": extra}
         nodes.upsert_node("node1", n)
         nodes.conn.commit()
         row = nodes.conn.execute(
@@ -52,5 +53,6 @@ def test_upsert_node_handles_position(tmp_path):
         assert row is not None
         data = json.loads(row[0])
         assert data["position"]["latitude"] == 52.5
+        assert data["extra"]["foo"] == "bar"
     finally:
         os.chdir(cwd)


### PR DESCRIPTION
## Summary
- Serialize non-dict mappings when snapshotting nodes
- Test node upserts with mapping proxy values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c53319cb2c832bb09b255501255645