### PR TITLE
Ignore Python __pycache__ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ Gemfile.lock
 
 # Used by RuboCop. Remote config files pulled in from inherit_from directive.
 .rubocop-https?--*
+
+# Python cache directories
+__pycache__/


### PR DESCRIPTION
## Summary
- ignore Python `__pycache__` directories

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c53418abc8832b9c4de500ceed8bcf