### PR TITLE
Filter stale nodes and add live search

### DIFF
--- a/web/app.rb
+++ b/web/app.rb
@@ -11,10 +11,12 @@ set :public_folder, File.join(__dir__, "public")
 def query_nodes(limit)
   db = SQLite3::Database.new(DB_PATH)
   db.results_as_hash = true
-  rows = db.execute <<~SQL, [limit]
+  min_last_heard = Time.now.to_i - 7 * 24 * 60 * 60
+  rows = db.execute <<~SQL, [min_last_heard, limit]
                       SELECT node_id, short_name, long_name, hw_model, role, snr, battery_level,
                              last_heard, position_time, latitude, longitude, altitude
                       FROM nodes
+                      WHERE last_heard >= ?
                       ORDER BY last_heard DESC
                       LIMIT ?
                     SQL

--- a/web/public/nodes.html
+++ b/web/public/nodes.html
@@ -34,6 +34,7 @@
     button { padding: 6px 10px; border: 1px solid #ccc; background: #fff; border-radius: 6px; cursor: pointer; }
     button:hover { background: #f6f6f6; }
     label { font-size: 14px; color: #333; }
+    input[type="text"] { padding: 6px 10px; border: 1px solid #ccc; border-radius: 6px; }
   </style>
 </head>
 <body>
@@ -45,6 +46,7 @@
     </div>
     <div class="controls">
       <label><input type="checkbox" id="fitBounds" checked /> Auto-fit map</label>
+      <input type="text" id="filterInput" placeholder="Filter nodes" />
       <button id="refreshBtn" type="button">Refresh now</button>
     </div>
   </div>
@@ -74,6 +76,8 @@
     const statusEl = document.getElementById('status');
     const fitBoundsEl = document.getElementById('fitBounds');
     const refreshBtn = document.getElementById('refreshBtn');
+    const filterInput = document.getElementById('filterInput');
+    let allNodes = [];
 
     // --- Map setup ---
     const map = L.map('map', { worldCopyJump: true });
@@ -158,12 +162,24 @@
       }
     }
 
+    function applyFilter() {
+      const q = filterInput.value.trim().toLowerCase();
+      const nodes = !q ? allNodes : allNodes.filter(n => {
+        return [n.node_id, n.short_name, n.long_name]
+          .filter(Boolean)
+          .some(v => v.toLowerCase().includes(q));
+      });
+      renderTable(nodes);
+      renderMap(nodes);
+    }
+
+    filterInput.addEventListener('input', applyFilter);
+
     async function refresh() {
       try {
         statusEl.textContent = 'refreshing…';
-        const nodes = await fetchNodes();
-        renderTable(nodes);
-        renderMap(nodes);
+        allNodes = await fetchNodes();
+        applyFilter();
         statusEl.textContent = 'updated ' + new Date().toLocaleTimeString();
       } catch (e) {
         statusEl.textContent = 'error: ' + e.message;


### PR DESCRIPTION
## Summary
- hide nodes older than 7 days from the `/nodes` view
- add a text box that filters nodes live on the map and table

## Testing
- `test/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c56121b054832bb8da53f8ebad852f