### PR TITLE
Adjust marker size and map tile opacity

### DIFF
--- a/web/public/nodes.html
+++ b/web/public/nodes.html
@@ -40,6 +40,7 @@
     input[type="text"] { padding: 6px 10px; border: 1px solid #ccc; border-radius: 6px; }
     .legend { background: #fff; padding: 6px 8px; border: 1px solid #ccc; border-radius: 4px; font-size: 12px; line-height: 18px; }
     .legend span { display: inline-block; width: 12px; height: 12px; margin-right: 6px; vertical-align: middle; }
+    #map .leaflet-tile { filter: opacity(70%); }
   </style>
 </head>
 <body>
@@ -187,11 +188,12 @@
 
         const color = roleColors[n.role] || '#3388ff';
         const marker = L.circleMarker([lat, lon], {
-          radius: 6,
+          radius: 12,
           color: '#000',
           weight: 1,
           fillColor: color,
-          fillOpacity: 1
+          fillOpacity: 0.7,
+          opacity: 0.7
         });
         const lines = [
           `<b>${n.short_name || ''}</b> <span class="mono">${n.node_id || ''}</span>`,


### PR DESCRIPTION
## Summary
- Double node map marker radius
- Set markers and background tiles to 70% opacity for softer visuals

## Testing
- `test/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c56caa6084832b8fb046defbe82098