### PR TITLE
Sort initial chat entries by last-heard

### DIFF
--- a/web/public/index.html
+++ b/web/public/index.html
@@ -240,11 +240,16 @@
       try {
         statusEl.textContent = 'refreshing…';
         const nodes = await fetchNodes();
+        const newNodes = [];
         for (const n of nodes) {
           if (n.node_id && !seenNodeIds.has(n.node_id)) {
-            addChatEntry(n);
+            newNodes.push(n);
             seenNodeIds.add(n.node_id);
           }
+        }
+        newNodes.sort((a, b) => (a.last_heard ?? 0) - (b.last_heard ?? 0));
+        for (const n of newNodes) {
+          addChatEntry(n);
         }
         allNodes = nodes;
         applyFilter();


### PR DESCRIPTION
## Summary
- ensure chat messages load in chronological order by sorting unseen nodes by last-heard before display

## Testing
- `./test/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c58d3f8380832b96651bd4801a494e