### PR TITLE
Ensure last_heard reflects update time

### DIFF
--- a/data/nodes.py
+++ b/data/nodes.py
@@ -28,6 +28,7 @@ def upsert_node(node_id, n):
     met = _get(n, "deviceMetrics") or {}
     pos = _get(n, "position") or {}
     lh = _get(n, "lastHeard")
+    now = int(time.time())
     row = (
         node_id,
         _get(n, "num"),
@@ -41,8 +42,8 @@ def upsert_node(node_id, n):
         _get(n, "isFavorite"),
         _get(n, "hopsAway"),
         _get(n, "snr"),
-        lh,
-        lh,
+        now,
+        lh or now,
         _get(met, "batteryLevel"),
         _get(met, "voltage"),
         _get(met, "channelUtilization"),

--- a/test/test_web_app.py
+++ b/test/test_web_app.py
@@ -42,11 +42,13 @@ def test_query_nodes_from_web_app(tmp_path):
     data = json.loads(out)
     conn = sqlite3.connect(db_path)
     threshold = int(time.time()) - 7 * 24 * 60 * 60
-    expected = conn.execute("SELECT COUNT(*) FROM nodes WHERE last_heard >= ?", (threshold,)).fetchone()[0]
-    old_count = conn.execute("SELECT COUNT(*) FROM nodes WHERE last_heard < ?", (threshold,)).fetchone()[0]
+    total = conn.execute("SELECT COUNT(*) FROM nodes").fetchone()[0]
+    recent = conn.execute(
+        "SELECT COUNT(*) FROM nodes WHERE last_heard >= ?", (threshold,)
+    ).fetchone()[0]
     conn.close()
-    assert old_count > 0
-    assert len(data) == expected
+    assert recent == total
+    assert len(data) == recent
     last_heards = [item["last_heard"] for item in data]
     assert last_heards == sorted(last_heards, reverse=True)
     assert all(lh is None or lh >= threshold for lh in last_heards)

--- a/web/app.rb
+++ b/web/app.rb
@@ -45,6 +45,7 @@ def upsert_node(db, node_id, n)
   pos = n["position"] || {}
   role = user["role"] || "CLIENT"
   lh = n["lastHeard"]
+  now = Time.now.to_i
   row = [
     node_id,
     n["num"],
@@ -58,8 +59,8 @@ def upsert_node(db, node_id, n)
     n["isFavorite"],
     n["hopsAway"],
     n["snr"],
-    lh,
-    lh,
+    now,
+    lh || now,
     met["batteryLevel"],
     met["voltage"],
     met["channelUtilization"],


### PR DESCRIPTION
## Summary
- Set `last_heard` to the current time whenever nodes are upserted
- Adjust tests for new `last_heard` semantics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c685deadfc832bb7e5947bff39f3ed