### PR TITLE
Ensure last_heard does not precede position time

### DIFF
--- a/data/nodes.py
+++ b/data/nodes.py
@@ -28,6 +28,9 @@ def upsert_node(node_id, n):
     met = _get(n, "deviceMetrics") or {}
     pos = _get(n, "position") or {}
     lh = _get(n, "lastHeard")
+    pt = _get(pos, "time")
+    if pt is not None and (lh is None or lh < pt):
+        lh = pt
     row = (
         node_id,
         _get(n, "num"),
@@ -48,7 +51,7 @@ def upsert_node(node_id, n):
         _get(met, "channelUtilization"),
         _get(met, "airUtilTx"),
         _get(met, "uptimeSeconds"),
-        _get(pos, "time"),
+        pt,
         _get(pos, "locationSource"),
         _get(pos, "latitude"),
         _get(pos, "longitude"),

--- a/test/test_nodes_serialization.py
+++ b/test/test_nodes_serialization.py
@@ -51,8 +51,8 @@ def test_upsert_node_handles_position(tmp_path):
         ).fetchone()
         assert row is not None
         assert row[0] == 52.5
-        assert row[1] == 100
-        assert row[2] == 100
+        assert row[1] == 123
+        assert row[2] == 123
 
         n["lastHeard"] = 200
         nodes.upsert_node("node1", n)
@@ -60,6 +60,6 @@ def test_upsert_node_handles_position(tmp_path):
         row2 = nodes.conn.execute(
             "SELECT first_heard, last_heard FROM nodes WHERE node_id=?", ("node1",)
         ).fetchone()
-        assert row2 == (100, 200)
+        assert row2 == (123, 200)
     finally:
         os.chdir(cwd)

--- a/test/test_web_app.py
+++ b/test/test_web_app.py
@@ -86,6 +86,12 @@ def test_post_nodes_to_web_app(tmp_path):
     assert lines[0] == "200"
     expected = len(json.load(open(nodes_json)))
     assert int(lines[1]) == expected
+    conn = sqlite3.connect(db_path)
+    bad = conn.execute(
+        "SELECT COUNT(*) FROM nodes WHERE position_time IS NOT NULL AND last_heard < position_time"
+    ).fetchone()[0]
+    conn.close()
+    assert bad == 0
 
 
 def test_null_role_defaults_to_client(tmp_path):

--- a/web/app.rb
+++ b/web/app.rb
@@ -45,6 +45,8 @@ def upsert_node(db, node_id, n)
   pos = n["position"] || {}
   role = user["role"] || "CLIENT"
   lh = n["lastHeard"]
+  pt = pos["time"]
+  lh = pt if pt && (!lh || lh < pt)
   row = [
     node_id,
     n["num"],
@@ -65,7 +67,7 @@ def upsert_node(db, node_id, n)
     met["channelUtilization"],
     met["airUtilTx"],
     met["uptimeSeconds"],
-    pos["time"],
+    pt,
     pos["locationSource"],
     pos["latitude"],
     pos["longitude"],


### PR DESCRIPTION
## Summary
- ensure `last_heard` is never earlier than a node's `position_time`
- verify ingestion logic adjusts stale `last_heard` values
- add regression tests for both Python and Ruby upserts

## Testing
- `bash test/test.sh` *(fails to fetch pytest but existing installation runs: 1 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c687cb241c832b81655da3d2bedcdf