### PR TITLE
Ensure last_heard does not precede position time

### DIFF
--- a/data/mesh.py
+++ b/data/mesh.py
@@ -37,6 +37,9 @@ def upsert_node(node_id, n):
     met = _get(n, "deviceMetrics") or {}
     pos = _get(n, "position") or {}
     lh = _get(n, "lastHeard")
+    pt = _get(pos, "time")
+    if pt is not None and (lh is None or lh < pt):
+        lh = pt
     row = (
         node_id,
         _get(n, "num"),
@@ -57,7 +60,7 @@ def upsert_node(node_id, n):
         _get(met, "channelUtilization"),
         _get(met, "airUtilTx"),
         _get(met, "uptimeSeconds"),
-        _get(pos, "time"),
+        pt,
         _get(pos, "locationSource"),
         _get(pos, "latitude"),
         _get(pos, "longitude"),

--- a/web/app.rb
+++ b/web/app.rb
@@ -45,6 +45,8 @@ def upsert_node(db, node_id, n)
   pos = n["position"] || {}
   role = user["role"] || "CLIENT"
   lh = n["lastHeard"]
+  pt = pos["time"]
+  lh = pt if pt && (!lh || lh < pt)
   row = [
     node_id,
     n["num"],
@@ -65,7 +67,7 @@ def upsert_node(db, node_id, n)
     met["channelUtilization"],
     met["airUtilTx"],
     met["uptimeSeconds"],
-    pos["time"],
+    pt,
     pos["locationSource"],
     pos["latitude"],
     pos["longitude"],


### PR DESCRIPTION
## Summary
- Guard `last_heard` against being older than `position_time` when upserting nodes
- Use adjusted timestamp for database persistence in both Ruby and Python implementations

## Testing
- `python -m py_compile data/mesh.py`
- `ruby -c web/app.rb`
- `python - <<'PY'
import os, importlib.util
os.environ['MESH_DB'] = ':memory:'
spec = importlib.util.spec_from_file_location('mesh', 'data/mesh.py')
mesh = importlib.util.module_from_spec(spec)
spec.loader.exec_module(mesh)
with mesh.DB_LOCK:
    mesh.conn.execute('DELETE FROM nodes')
mesh.upsert_node('abc', {'lastHeard': 100, 'position': {'time': 200}})
with mesh.DB_LOCK:
    row = mesh.conn.execute('SELECT last_heard, position_time FROM nodes WHERE node_id=?', ('abc',)).fetchone()
print(row)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c68d367eb0832bb02e27cf77b1a1b3