### PR TITLE
refactor: replace deprecated utcfromtimestamp

### DIFF
--- a/data/mesh.py
+++ b/data/mesh.py
@@ -89,7 +89,11 @@ def upsert_node(node_id, n):
 # --- Message logging via PubSub -----------------------------------------------
 def _iso(ts: int | float) -> str:
     import datetime
-    return datetime.datetime.utcfromtimestamp(int(ts)).isoformat() + "Z"
+    return (
+        datetime.datetime.fromtimestamp(int(ts), datetime.UTC)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
 
 def _first(d: dict, *names, default=None):
     """Return first present key from names (supports nested 'a.b' lookups)."""


### PR DESCRIPTION
## Summary
- use timezone-aware `datetime.fromtimestamp(..., datetime.UTC)` when rendering ISO timestamps

## Testing
- `pytest -q`
- `python -m py_compile data/mesh.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6acd73620832b9cf91b7f0a63e225