### PR TITLE
Clamp node timestamps and sync last_heard with position time

### DIFF
--- a/data/mesh.py
+++ b/data/mesh.py
@@ -37,6 +37,14 @@ def upsert_node(node_id, n):
     met = _get(n, "deviceMetrics") or {}
     pos = _get(n, "position") or {}
     lh = _get(n, "lastHeard")
+    pt = _get(pos, "time")
+    now = int(time.time())
+    if lh is not None and lh > now:
+        lh = now
+    if pt is not None and pt > now:
+        pt = now
+    if pt is not None and (lh is None or lh < pt):
+        lh = pt
     row = (
         node_id,
         _get(n, "num"),
@@ -57,7 +65,7 @@ def upsert_node(node_id, n):
         _get(met, "channelUtilization"),
         _get(met, "airUtilTx"),
         _get(met, "uptimeSeconds"),
-        _get(pos, "time"),
+        pt,
         _get(pos, "locationSource"),
         _get(pos, "latitude"),
         _get(pos, "longitude"),

--- a/web/app.rb
+++ b/web/app.rb
@@ -45,6 +45,11 @@ def upsert_node(db, node_id, n)
   pos = n["position"] || {}
   role = user["role"] || "CLIENT"
   lh = n["lastHeard"]
+  pt = pos["time"]
+  now = Time.now.to_i
+  lh = now if lh && lh > now
+  pt = now if pt && pt > now
+  lh = pt if pt && (!lh || lh < pt)
   row = [
     node_id,
     n["num"],
@@ -65,7 +70,7 @@ def upsert_node(db, node_id, n)
     met["channelUtilization"],
     met["airUtilTx"],
     met["uptimeSeconds"],
-    pos["time"],
+    pt,
     pos["locationSource"],
     pos["latitude"],
     pos["longitude"],


### PR DESCRIPTION
## Summary
- Clamp incoming last_heard and position_time to current time
- Ensure last_heard is at least the position time when updating nodes

## Testing
- `python -m py_compile data/mesh.py`
- `ruby -c web/app.rb`


------
https://chatgpt.com/codex/tasks/task_e_68c6aae860e8832b812510f3bc97eeae