### PR TITLE
Optimize web frontend and Ruby app

### DIFF
--- a/web/app.rb
+++ b/web/app.rb
@@ -5,13 +5,15 @@ require "sqlite3"
 
 # run ../data/mesh.sh to populate nodes and messages database
 DB_PATH = ENV.fetch("MESH_DB", File.join(__dir__, "../data/mesh.db"))
+WEEK_SECONDS = 7 * 24 * 60 * 60
 
 set :public_folder, File.join(__dir__, "public")
 
 def query_nodes(limit)
-  db = SQLite3::Database.new(DB_PATH)
+  db = SQLite3::Database.new(DB_PATH, readonly: true)
   db.results_as_hash = true
-  min_last_heard = Time.now.to_i - 7 * 24 * 60 * 60
+  now = Time.now.to_i
+  min_last_heard = now - WEEK_SECONDS
   rows = db.execute <<~SQL, [min_last_heard, limit]
                       SELECT node_id, short_name, long_name, hw_model, role, snr,
                              battery_level, voltage, last_heard, first_heard,
@@ -24,9 +26,10 @@ def query_nodes(limit)
                     SQL
   rows.each do |r|
     r["role"] ||= "CLIENT"
-    lh = r["last_heard"]; pt = r["position_time"]
-    r["last_seen_iso"] = lh ? Time.at(lh.to_i).utc.iso8601 : nil
-    r["pos_time_iso"] = pt ? Time.at(pt.to_i).utc.iso8601 : nil
+    lh = r["last_heard"]
+    pt = r["position_time"]
+    r["last_seen_iso"] = Time.at(lh.to_i).utc.iso8601 if lh
+    r["pos_time_iso"] = Time.at(pt.to_i).utc.iso8601 if pt
   end
   rows
 ensure

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -1,4 +1,3 @@
-</html>
 <!doctype html>
 <html lang="en">
 <head>
@@ -104,8 +103,9 @@
     const baseTitle = document.title;
     let allNodes = [];
     const seenNodeIds = new Set();
+    const NODE_LIMIT = 1000;
 
-    const roleColors = {
+    const roleColors = Object.freeze({
       CLIENT: '#A8D5BA',
       CLIENT_HIDDEN: '#B8DCA9',
       CLIENT_MUTE: '#D2E3A2',
@@ -115,7 +115,7 @@
       REPEATER: '#F7B7A3',
       ROUTER_LATE: '#F29AA3',
       ROUTER: '#E88B94'
-    };
+    });
 
     // --- Map setup ---
     const map = L.map('map', { worldCopyJump: true });
@@ -162,30 +162,21 @@
     }
 
     function fmtHw(v) {
-      if (v == null) return "";
-      if (v == "UNSET") return "";
-      return String(v);
+      return v && v !== "UNSET" ? String(v) : "";
     }
 
     function fmtCoords(v, d = 5) {
-      if (v == null) return "";
       const n = Number(v);
-      return Number.isNaN(n) ? "" : n.toFixed(d);
+      return Number.isFinite(n) ? n.toFixed(d) : "";
     }
 
     function fmtAlt(v, s) {
-      if (v == null) return "";
-      if (v == 0) return "";
-      const n = String(v) + String(s);
-      return n;
+      return v ? `${v}${s}` : "";
     }
 
     function fmtTx(v, d = 3) {
-      if (v == null) return "";
-      let n = Number(v);
-      n = Number.isNaN(n) ? "" : n.toFixed(d);
-      n = String(n) + "%";
-      return n;
+      const n = Number(v);
+      return Number.isFinite(n) ? `${n.toFixed(d)}%` : "";
     }
 
     function timeHum(unixSec) {
@@ -207,15 +198,15 @@
       return `${Math.floor(diff/86400)}d ${Math.floor((diff%86400)/3600)}h`;
     }
 
-    async function fetchNodes() {
-      const r = await fetch('/api/nodes?limit=1000', { cache: 'no-store' });
+    async function fetchNodes(limit = NODE_LIMIT) {
+      const r = await fetch(`/api/nodes?limit=${limit}`, { cache: 'no-store' });
       if (!r.ok) throw new Error('HTTP ' + r.status);
       return r.json();
     }
 
     function renderTable(nodes) {
       const tb = document.querySelector('#nodes tbody');
-      tb.innerHTML = '';
+      const frag = document.createDocumentFragment();
       for (const n of nodes) {
         const tr = document.createElement('tr');
         tr.innerHTML = `
@@ -234,17 +225,17 @@
           <td>${fmtCoords(n.longitude)}</td>
           <td>${fmtAlt(n.altitude, "m")}</td>
           <td class="mono">${n.pos_time_iso ? `${timeAgo(n.position_time)}` : ""}</td>`;
-        tb.appendChild(tr);
+        frag.appendChild(tr);
       }
+      tb.replaceChildren(frag);
     }
 
     function renderMap(nodes) {
       markersLayer.clearLayers();
       const pts = [];
       for (const n of nodes) {
-        if (n.latitude == null || n.longitude == null) continue;
         const lat = Number(n.latitude), lon = Number(n.longitude);
-        if (Number.isNaN(lat) || Number.isNaN(lon)) continue;
+        if (!Number.isFinite(lat) || !Number.isFinite(lon)) continue;
 
         const color = roleColors[n.role] || '#3388ff';
         const marker = L.circleMarker([lat, lon], {


### PR DESCRIPTION
## Summary
- Open SQLite in read-only mode and centralize week-length constant for node queries.
- Clean up HTML and streamline frontend code with frozen role colors, reusable node limit, and concise format helpers.
- Batch table rendering and validate coordinates more robustly.

## Testing
- `ruby -c web/app.rb`


------
https://chatgpt.com/codex/tasks/task_e_68c6e56aa180832b9e57be0ce855b364