### PR TITLE
Handle future timestamps gracefully

### DIFF
--- a/data/mesh.py
+++ b/data/mesh.py
@@ -38,11 +38,6 @@ def upsert_node(node_id, n):
     pos = _get(n, "position") or {}
     lh = _get(n, "lastHeard")
     pt = _get(pos, "time")
-    now = int(time.time())
-    if lh is not None and lh > now:
-        lh = now
-    if pt is not None and pt > now:
-        pt = now
     if pt is not None and (lh is None or lh < pt):
         lh = pt
     row = (

--- a/web/app.rb
+++ b/web/app.rb
@@ -46,9 +46,6 @@ def upsert_node(db, node_id, n)
   role = user["role"] || "CLIENT"
   lh = n["lastHeard"]
   pt = pos["time"]
-  now = Time.now.to_i
-  lh = now if lh && lh > now
-  pt = now if pt && pt > now
   lh = pt if pt && (!lh || lh < pt)
   row = [
     node_id,

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -200,9 +200,15 @@
     function timeAgo(unixSec) {
       if (!unixSec) return "";
       const diff = Math.floor(Date.now()/1000 - Number(unixSec));
-      if (diff < 0) return "0s";
+      if (diff < 0) {
+        const future = -diff;
+        if (future < 60) return `in ${future}s`;
+        if (future < 3600) return `in ${Math.floor(future/60)}m ${Math.floor(future%60)}s`;
+        if (future < 86400) return `in ${Math.floor(future/3600)}h ${Math.floor((future%3600)/60)}m`;
+        return `in ${Math.floor(future/86400)}d ${Math.floor((future%86400)/3600)}h`;
+      }
       if (diff < 60) return `${diff}s`;
-      if (diff < 3600) return `${Math.floor(diff/60)}m ${Math.floor((diff%60))}s`;
+      if (diff < 3600) return `${Math.floor(diff/60)}m ${Math.floor(diff%60)}s`;
       if (diff < 86400) return `${Math.floor(diff/3600)}h ${Math.floor((diff%3600)/60)}m`;
       return `${Math.floor(diff/86400)}d ${Math.floor((diff%86400)/3600)}h`;
     }


### PR DESCRIPTION
## Summary
- Preserve future last-heard and position times rather than clamping them to the current time
- Show future timestamps as upcoming intervals (e.g. `in 5s`) on the web UI

## Testing
- `pytest`
- `ruby -c web/app.rb`


------
https://chatgpt.com/codex/tasks/task_e_68c6e7516c30832baf63fdeb60ffc446