### PR TITLE
Normalize future timestamps for nodes

### DIFF
--- a/data/mesh.py
+++ b/data/mesh.py
@@ -39,10 +39,10 @@ def upsert_node(node_id, n):
     lh = _get(n, "lastHeard")
     pt = _get(pos, "time")
     now = int(time.time())
+    if pt is not None and pt > now:
+        pt = None
     if lh is not None and lh > now:
         lh = now
-    if pt is not None and pt > now:
-        pt = now
     if pt is not None and (lh is None or lh < pt):
         lh = pt
     row = (

--- a/web/app.rb
+++ b/web/app.rb
@@ -27,6 +27,10 @@ def query_nodes(limit)
     r["role"] ||= "CLIENT"
     lh = r["last_heard"]
     pt = r["position_time"]
+    lh = now if lh && lh > now
+    pt = nil if pt && pt > now
+    r["last_heard"] = lh
+    r["position_time"] = pt
     r["last_seen_iso"] = Time.at(lh.to_i).utc.iso8601 if lh
     r["pos_time_iso"] = Time.at(pt.to_i).utc.iso8601 if pt
   end
@@ -80,8 +84,8 @@ def upsert_node(db, node_id, n)
   lh = n["lastHeard"]
   pt = pos["time"]
   now = Time.now.to_i
+  pt = nil if pt && pt > now
   lh = now if lh && lh > now
-  pt = now if pt && pt > now
   lh = pt if pt && (!lh || lh < pt)
   row = [
     node_id,


### PR DESCRIPTION
## Summary
- Avoid returning future position times by discarding them during node queries
- Clamp future last-heard timestamps to current time on upsert
- Mirror timestamp normalization in Python mesh data writer

## Testing
- `ruby -c web/app.rb`
- `python -m py_compile data/mesh.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6fcbe172c832b9eb86210a05f04b6