### PR TITLE
Sort chat entries by timestamp

### DIFF
--- a/web/public/index.html
+++ b/web/public/index.html
@@ -319,10 +319,6 @@
             seenNodeIds.add(n.node_id);
           }
         }
-        newNodes.sort((a, b) => (a.first_heard ?? 0) - (b.first_heard ?? 0));
-        for (const n of newNodes) {
-          addNewNodeChatEntry(n);
-        }
         const messages = await fetchMessages();
         const newMessages = [];
         for (const m of messages) {
@@ -331,9 +327,16 @@
             seenMessageIds.add(m.id);
           }
         }
-        newMessages.sort((a, b) => (a.rx_time ?? 0) - (b.rx_time ?? 0));
-        for (const m of newMessages) {
-          addNewMessageChatEntry(m);
+        const entries = [];
+        for (const n of newNodes) entries.push({ type: 'node', ts: n.first_heard ?? 0, item: n });
+        for (const m of newMessages) entries.push({ type: 'msg', ts: m.rx_time ?? 0, item: m });
+        entries.sort((a, b) => {
+          if (a.ts !== b.ts) return a.ts - b.ts;
+          return a.type === 'node' && b.type === 'msg' ? -1 : a.type === 'msg' && b.type === 'node' ? 1 : 0;
+        });
+        for (const e of entries) {
+          if (e.type === 'node') addNewNodeChatEntry(e.item);
+          else addNewMessageChatEntry(e.item);
         }
         allNodes = nodes;
         applyFilter();

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -316,7 +316,6 @@
         for (const n of nodes) {
           if (n.node_id && !seenNodeIds.has(n.node_id)) {
             newNodes.push(n);
-            seenNodeIds.add(n.node_id);
           }
         }
         const messages = await fetchMessages();
@@ -324,7 +323,6 @@
         for (const m of messages) {
           if (m.id && !seenMessageIds.has(m.id)) {
             newMessages.push(m);
-            seenMessageIds.add(m.id);
           }
         }
         const entries = [];
@@ -335,8 +333,13 @@
           return a.type === 'node' && b.type === 'msg' ? -1 : a.type === 'msg' && b.type === 'node' ? 1 : 0;
         });
         for (const e of entries) {
-          if (e.type === 'node') addNewNodeChatEntry(e.item);
-          else addNewMessageChatEntry(e.item);
+          if (e.type === 'node') {
+            addNewNodeChatEntry(e.item);
+            if (e.item.node_id) seenNodeIds.add(e.item.node_id);
+          } else {
+            addNewMessageChatEntry(e.item);
+            if (e.item.id) seenMessageIds.add(e.item.id);
+          }
         }
         allNodes = nodes;
         applyFilter();


### PR DESCRIPTION
## Summary
- Combine new nodes and messages into a single list
- Sort chat seed entries chronologically with nodes first on ties

## Testing
- `ruby -c web/app.rb`
- `python -m py_compile test/debug.py`


------
https://chatgpt.com/codex/tasks/task_e_68c70215a110832bbeb6f37164a16b88