### PR TITLE
Escape chat message and node entries

### DIFF
--- a/web/public/index.html
+++ b/web/public/index.html
@@ -144,13 +144,27 @@
     legend.addTo(map);
 
     // --- Helpers ---
-    function renderShortHtml(short){ return String(short).padStart(4, ' ').replace(/ /g, '&nbsp;'); }
+    function escapeHtml(str) {
+      return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+
+    function renderShortHtml(short){
+      return escapeHtml(String(short).padStart(4, ' ')).replace(/ /g, '&nbsp;');
+    }
 
     function addNewNodeChatEntry(n) {
       const div = document.createElement('div');
       const ts = formatDate(new Date(n.first_heard * 1000));
       div.className = 'chat-entry-node';
-      div.innerHTML = `[${ts}] ${n.node_id || ''} ${renderShortHtml(n.short_name || '')} <em>New node: ${n.long_name || ''}</em>`;
+      const nodeId = escapeHtml(n.node_id || '');
+      const short = renderShortHtml(n.short_name || '');
+      const longName = escapeHtml(n.long_name || '');
+      div.innerHTML = `[${ts}] ${nodeId} ${short} <em>New node: ${longName}</em>`;
       chatEl.appendChild(div);
       chatEl.scrollTop = chatEl.scrollHeight;
     }
@@ -158,9 +172,9 @@
     function addNewMessageChatEntry(m) {
       const div = document.createElement('div');
       const ts = formatDate(new Date(m.rx_time * 1000));
-      const from = m.from_id || '<em>(unknown)</em>';
+      const from = m.from_id ? escapeHtml(m.from_id) : '<em>(unknown)</em>';
       const short = renderShortHtml(m.node?.short_name || '');
-      const text = m.text || '';
+      const text = escapeHtml(m.text || '');
       div.className = 'chat-entry-msg';
       div.innerHTML = `[${ts}] ${from} ${short} ${text}`;
       chatEl.appendChild(div);


### PR DESCRIPTION
## Summary
- Escape HTML characters for chat message and node entries to prevent XSS
- Ensure short name rendering uses escaped content

## Testing
- `python -m pytest 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68c70250d160832b93a89503758734e9