### PR TITLE
Limit chat log and highlight short names by role

### DIFF
--- a/web/public/index.html
+++ b/web/public/index.html
@@ -34,6 +34,7 @@
     #chat { flex: 0 0 33%; max-width: 33%; height: 60vh; border: 1px solid #ddd; border-radius: 8px; overflow-y: auto; padding: 6px; font-size: 12px; }
     .chat-entry-node { font-family: ui-monospace, Menlo, Consolas, monospace; color: #555 }
     .chat-entry-msg { font-family: ui-monospace, Menlo, Consolas, monospace; }
+    .short-name { display:inline-block; border-radius:4px; padding:0 2px; }
     .controls { display: flex; gap: 8px; align-items: center; }
     button { padding: 6px 10px; border: 1px solid #ccc; background: #fff; border-radius: 6px; cursor: pointer; }
     button:hover { background: #f6f6f6; }
@@ -107,6 +108,7 @@
     const seenNodeIds = new Set();
     const seenMessageIds = new Set();
     const NODE_LIMIT = 1000;
+    const CHAT_LIMIT = 1000;
     const REFRESH_MS = 60000;
     refreshInfo.textContent = `#MediumFast — auto-refresh every ${REFRESH_MS / 1000} seconds.`;
 
@@ -153,8 +155,21 @@
         .replace(/'/g, '&#39;');
     }
 
-    function renderShortHtml(short){
-      return escapeHtml(String(short).padStart(4, ' ')).replace(/ /g, '&nbsp;');
+    function renderShortHtml(short, role){
+      if (!short) {
+        return `<span class="short-name" style="background:#ccc">&nbsp;&nbsp;&nbsp;&nbsp;</span>`;
+      }
+      const padded = String(short).padStart(4, ' ').replace(/ /g, '&nbsp;');
+      const color = roleColors[role] || roleColors.CLIENT;
+      return `<span class="short-name" style="background:${color}">${padded}</span>`;
+    }
+
+    function appendChatEntry(div) {
+      chatEl.appendChild(div);
+      while (chatEl.childElementCount > CHAT_LIMIT) {
+        chatEl.removeChild(chatEl.firstChild);
+      }
+      chatEl.scrollTop = chatEl.scrollHeight;
     }
 
     function addNewNodeChatEntry(n) {
@@ -162,23 +177,21 @@
       const ts = formatDate(new Date(n.first_heard * 1000));
       div.className = 'chat-entry-node';
       const nodeId = escapeHtml(n.node_id || '');
-      const short = renderShortHtml(n.short_name || '');
+      const short = renderShortHtml(n.short_name, n.role);
       const longName = escapeHtml(n.long_name || '');
       div.innerHTML = `[${ts}] ${nodeId} ${short} <em>New node: ${longName}</em>`;
-      chatEl.appendChild(div);
-      chatEl.scrollTop = chatEl.scrollHeight;
+      appendChatEntry(div);
     }
 
     function addNewMessageChatEntry(m) {
       const div = document.createElement('div');
       const ts = formatDate(new Date(m.rx_time * 1000));
       const from = m.from_id ? escapeHtml(m.from_id) : '<em>(unknown)</em>';
-      const short = renderShortHtml(m.node?.short_name || '');
+      const short = renderShortHtml(m.node?.short_name, m.node?.role);
       const text = escapeHtml(m.text || '');
       div.className = 'chat-entry-msg';
       div.innerHTML = `[${ts}] ${from} ${short} ${text}`;
-      chatEl.appendChild(div);
-      chatEl.scrollTop = chatEl.scrollHeight;
+      appendChatEntry(div);
     }
 
     function pad(n) { return String(n).padStart(2, "0"); }
@@ -250,7 +263,7 @@
         const tr = document.createElement('tr');
         tr.innerHTML = `
           <td class="mono">${n.node_id || ""}</td>
-          <td>${n.short_name || ""}</td>
+          <td>${renderShortHtml(n.short_name, n.role)}</td>
           <td>${n.long_name || ""}</td>
           <td>${timeAgo(n.last_heard, nowSec)}</td>
           <td>${n.role || "CLIENT"}</td>
@@ -289,7 +302,7 @@
         });
         const lines = [
           `<b>${n.long_name || ''}</b>`,
-          `<b>${n.short_name || ''}</b> <span class="mono">${n.node_id || ''}</span>`,
+          `${renderShortHtml(n.short_name, n.role)} <span class="mono">${n.node_id || ''}</span>`,
           n.hw_model ? `Model: ${fmtHw(n.hw_model)}` : null,
           `Role: ${n.role || 'CLIENT'}`,
           (n.battery_level != null ? `Battery: ${fmtAlt(n.battery_level, "%")}, ${fmtAlt(n.voltage, "V")}` : null),


### PR DESCRIPTION
## Summary
- cap chat panel to the latest 1000 entries to prevent unbounded growth
- show node short names in rounded role-colored boxes with padding and grey fallback

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c713464180832ba753c9b837c689c3