### PR TITLE
Harden mesh utilities

### DIFF
--- a/data/mesh.sh
+++ b/data/mesh.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-python -m venv .venv && source .venv/bin/activate
-pip install meshtastic
-python mesh.py
+python -m venv .venv
+source .venv/bin/activate
+pip install -U meshtastic
+exec python mesh.py

--- a/web/app.rb
+++ b/web/app.rb
@@ -46,7 +46,7 @@ get "/api/nodes" do
 end
 
 def query_messages(limit)
-  db = SQLite3::Database.new(DB_PATH)
+  db = SQLite3::Database.new(DB_PATH, readonly: true)
   db.results_as_hash = true
   rows = db.execute <<~SQL, [limit]
                       SELECT m.*, n.*, m.snr AS msg_snr

--- a/web/app.sh
+++ b/web/app.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 bundle install
-ruby app.rb -p 41447 -o 127.0.0.1
+exec ruby app.rb -p 41447 -o 127.0.0.1


### PR DESCRIPTION
## Summary
- reject non-text-message packets and simplify PubSub error handling
- open message DB in read-only mode
- harden helper scripts with strict bash options

## Testing
- `python -m py_compile data/mesh.py`
- `ruby -c web/app.rb`
- `bash -n data/mesh.sh`
- `bash -n web/app.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c718d68c64832bb9fa1c157dc7b116