### PR TITLE
Show daily node count in title and header

### DIFF
--- a/web/public/index.html
+++ b/web/public/index.html
@@ -377,7 +377,7 @@
       const nowSec = Date.now()/1000;
       renderTable(nodes, nowSec);
       renderMap(nodes, nowSec);
-      updateCount(nodes.length);
+      updateCount(nodes, nowSec);
       updateRefreshInfo(nodes, nowSec);
     }
 
@@ -430,7 +430,9 @@
     setInterval(refresh, REFRESH_MS);
     refreshBtn.addEventListener('click', refresh);
 
-    function updateCount(count) {
+    function updateCount(nodes, nowSec) {
+      const dayAgoSec = nowSec - 86400;
+      const count = nodes.filter(n => n.last_heard && Number(n.last_heard) >= dayAgoSec).length;
       const text = `${baseTitle} (${count})`;
       titleEl.textContent = text;
       headerEl.textContent = text;


### PR DESCRIPTION
## Summary
- filter nodes seen in the last day and display that count in the page title and header

## Testing
- `python -m py_compile data/mesh.py`
- `ruby -c web/app.rb`


------
https://chatgpt.com/codex/tasks/task_e_68c73b4c8860832b90e52fdcf7ff03c3