### PR TITLE
Add tests and CI with Codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+          working-directory: web
+      - name: Run Ruby tests
+        working-directory: web
+        run: bundle exec rspec
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Run JS tests
+        run: npm test
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,12 @@
 /test/version_tmp/
 /tmp/
 
+# Test artifacts
+/web/coverage-ruby/
+/web/coverage-js/
+/web/spec/test.db
+/web/test/test.db
+
 # Used by dotenv library to load environment variables.
 # .env
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "potato-mesh",
+  "version": "1.0.0",
+  "description": "a simple node dashboard for berlin mediumfast",
+  "main": "index.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "NODE_V8_COVERAGE=web/coverage-js node --test web/test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/web/Gemfile
+++ b/web/Gemfile
@@ -4,3 +4,9 @@ gem "sinatra", "~> 4.0"
 gem "sqlite3", "~> 1.7"
 gem "rackup", "~> 2.2"
 gem "puma", "~> 7.0"
+
+group :development, :test do
+  gem "rspec", "~> 3.12"
+  gem "rack-test", "~> 2.1"
+  gem "simplecov", "~> 0.22"
+end

--- a/web/public/utils.js
+++ b/web/public/utils.js
@@ -1,0 +1,9 @@
+function timeHum(unixSec) {
+  if (!unixSec) return "";
+  if (unixSec < 0) return "0s";
+  if (unixSec < 60) return `${unixSec}s`;
+  if (unixSec < 3600) return `${Math.floor(unixSec/60)}m ${Math.floor((unixSec%60))}s`;
+  if (unixSec < 86400) return `${Math.floor(unixSec/3600)}h ${Math.floor((unixSec%3600)/60)}m`;
+  return `${Math.floor(unixSec/86400)}d ${Math.floor((unixSec%86400)/3600)}h`;
+}
+module.exports = { timeHum };

--- a/web/spec/app_spec.rb
+++ b/web/spec/app_spec.rb
@@ -1,0 +1,22 @@
+require_relative 'spec_helper'
+require_relative '../app'
+require 'json'
+
+RSpec.describe 'App' do
+  def app
+    Sinatra::Application
+  end
+
+  it 'serves index page' do
+    get '/'
+    expect(last_response).to be_ok
+    expect(last_response.body).to include('<!doctype html>')
+  end
+
+  it 'returns nodes json' do
+    get '/api/nodes'
+    expect(last_response).to be_ok
+    data = JSON.parse(last_response.body)
+    expect(data.first['node_id']).to eq('node1')
+  end
+end

--- a/web/spec/spec_helper.rb
+++ b/web/spec/spec_helper.rb
@@ -1,0 +1,17 @@
+require 'simplecov'
+SimpleCov.coverage_dir 'coverage-ruby'
+SimpleCov.start do
+  add_filter '/spec/'
+end
+
+require_relative '../test/support/create_db'
+DB_PATH = File.join(__dir__, 'test.db')
+create_test_db(DB_PATH)
+ENV['MESH_DB'] = DB_PATH
+
+require 'rack/test'
+require 'rspec'
+
+RSpec.configure do |config|
+  config.include Rack::Test::Methods
+end

--- a/web/test/e2e.test.js
+++ b/web/test/e2e.test.js
@@ -1,0 +1,31 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { spawn } = require('node:child_process');
+const path = require('node:path');
+const fetch = global.fetch;
+
+const appDir = path.join(__dirname, '..');
+const supportDir = path.join(appDir, 'test', 'support');
+
+// ensure test database exists
+const createDb = spawn('ruby', [path.join(supportDir, 'create_db.rb'), path.join(__dirname, 'test.db')], { cwd: appDir });
+
+const wait = ms => new Promise(r => setTimeout(r, ms));
+
+async function startServer() {
+  await new Promise(res => createDb.on('exit', res));
+  const server = spawn('ruby', ['app.rb'], { cwd: appDir, env: { ...process.env, MESH_DB: path.join(__dirname, 'test.db') } });
+  await wait(500); // wait for server to boot
+  return server;
+}
+
+test('fetch nodes from running server', async (t) => {
+  const server = await startServer();
+  try {
+    const res = await fetch('http://localhost:4567/api/nodes');
+    const json = await res.json();
+    assert.ok(Array.isArray(json));
+  } finally {
+    server.kill();
+  }
+});

--- a/web/test/support/create_db.rb
+++ b/web/test/support/create_db.rb
@@ -1,0 +1,19 @@
+require 'sqlite3'
+require 'time'
+
+def create_test_db(path)
+  File.delete(path) if File.exist?(path)
+  db = SQLite3::Database.new(path)
+  root = File.expand_path('../../../..', __dir__)
+  db.execute_batch File.read(File.join(root, 'data', 'nodes.sql'))
+  db.execute_batch File.read(File.join(root, 'data', 'messages.sql'))
+  now = Time.now.to_i
+  iso = Time.at(now).utc.iso8601
+  db.execute("INSERT INTO nodes (node_id, short_name, long_name, role, last_heard, first_heard) VALUES (?,?,?,?,?,?)", ['node1','N1','Node 1','CLIENT', now, now])
+  db.execute("INSERT INTO messages (rx_time, rx_iso, from_id, to_id, channel, portnum, text, snr) VALUES (?,?,?,?,?,?,?,?)", [now, iso, 'node1','node2',1,'TEXT_MESSAGE_APP','hi',5])
+  db.close
+end
+
+if __FILE__ == $0
+  create_test_db(ARGV[0] || File.join(__dir__, '..', 'test.db'))
+end

--- a/web/test/unit.test.js
+++ b/web/test/unit.test.js
@@ -1,0 +1,7 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { timeHum } = require('../public/utils');
+
+test('timeHum formats seconds', () => {
+  assert.strictEqual(timeHum(65), '1m 5s');
+});


### PR DESCRIPTION
## Summary
- add utility module and tests for front-end JS
- add RSpec tests for Sinatra API and helper scripts for test DB
- configure CI workflow running Ruby and JS tests with Codecov upload

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403)*
- `bundle exec rspec` *(fails: command not found)*
- `npm test` *(fails: fetch failed in e2e test)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a20f512c832b99f28114eb3bf2d9