### PR TITLE
feat: parameterize community info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # potato-mesh
 
- a simple meshtastic node dashboard for your local community. here: berlin mediumfast.
+ a simple meshtastic node dashboard for your local community.
 
  demo: [potatomesh.net](https://potatomesh.net)
 
@@ -24,7 +24,6 @@ what works:
 what does not work _(yet):_
 
 * posting nodes and messages to the api endpoints _(wip)_
-* white-label for your community (need to updated some berlin-specific hardcoded stuff)
 
 ## requirements
 
@@ -80,6 +79,19 @@ Puma starting in single mode...
 ```
 
 set `API_TOKEN` required for authorizations on the api post-endpoints (wip).
+
+the web app can be configured with environment variables:
+
+* `SITE_NAME` - title and header shown in the ui (default: "meshtastic network")
+* `MAP_CENTER_LAT` / `MAP_CENTER_LON` - default map center coordinates (default: `0` / `0`)
+* `MAX_NODE_DISTANCE_KM` - hide nodes farther than this distance from the center (default: `1000`)
+* `MATRIX_ROOM` - matrix room id for a footer link, optional
+
+example:
+
+```bash
+SITE_NAME="meshtastic town" MAP_CENTER_LAT=51.5 MAP_CENTER_LON=-0.12 MATRIX_ROOM="#meshtastic-town:matrix.org" ./app.sh
+```
 
 ## api
 

--- a/test/messages.json
+++ b/test/messages.json
@@ -807,7 +807,7 @@
       "to_id":"^all",
       "channel":0,
       "portnum":"TEXT_MESSAGE_APP",
-      "text":"Weiss einer welche Modem Betriebsart auf 433MHz in Berlin genutzt wird, war auf LF und kein Empfang.",
+      "text":"Weiss einer welche Modem Betriebsart auf 433MHz in unserer Stadt genutzt wird, war auf LF und kein Empfang.",
       "rssi":-43,
       "hop_limit":3,
       "raw_json":null,

--- a/test/nodes.json
+++ b/test/nodes.json
@@ -1926,7 +1926,7 @@
     "num": 29067483,
     "user": {
       "id": "!01bb88db",
-      "longName": "Gedenkst\u00e4tte Berliner Mauer",
+      "longName": "City Wall Memorial",
       "shortName": "GSBM",
       "macaddr": "d9:58:01:bb:88:db",
       "hwModel": "HELTEC_MESH_NODE_T114",

--- a/web/app.rb
+++ b/web/app.rb
@@ -8,6 +8,13 @@ DB_PATH = ENV.fetch("MESH_DB", File.join(__dir__, "../data/mesh.db"))
 WEEK_SECONDS = 7 * 24 * 60 * 60
 
 set :public_folder, File.join(__dir__, "public")
+set :views, File.join(__dir__, "views")
+
+SITE_NAME = ENV.fetch("SITE_NAME", "Meshtastic Network")
+MAP_CENTER_LAT = ENV.fetch("MAP_CENTER_LAT", "0").to_f
+MAP_CENTER_LON = ENV.fetch("MAP_CENTER_LON", "0").to_f
+MAX_NODE_DISTANCE_KM = ENV.fetch("MAX_NODE_DISTANCE_KM", "1000").to_f
+MATRIX_ROOM = ENV["MATRIX_ROOM"]
 
 def query_nodes(limit)
   db = SQLite3::Database.new(DB_PATH, readonly: true, results_as_hash: true)
@@ -155,5 +162,11 @@ ensure
 end
 
 get "/" do
-  send_file File.join(settings.public_folder, "index.html")
+  erb :index, locals: {
+    site_name: SITE_NAME,
+    map_center_lat: MAP_CENTER_LAT,
+    map_center_lon: MAP_CENTER_LON,
+    max_node_distance_km: MAX_NODE_DISTANCE_KM,
+    matrix_room: MATRIX_ROOM
+  }
 end

--- a/web/views/index.erb
+++ b/web/views/index.erb
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Meshtastic Berlin</title>
+  <title><%= site_name %></title>
 
   <!-- Leaflet CSS/JS (CDN) -->
   <link
@@ -73,7 +73,7 @@
   </style>
 </head>
 <body>
-  <h1>Meshtastic Berlin</h1>
+  <h1><%= site_name %></h1>
   <div class="row meta">
     <div>
       <span id="refreshInfo"></span>
@@ -116,9 +116,11 @@
   </table>
 
   <footer>
-    PotatoMesh GitHub: <a href="https://github.com/l5yth/potato-mesh" target="_blank">l5yth/potato-mesh</a> —
-    Meshtastic Berlin Matrix:
-    <a href="https://matrix.to/#/#meshtastic-berlin:matrix.org" target="_blank">#meshtastic-berlin:matrix.org</a>
+    PotatoMesh GitHub: <a href="https://github.com/l5yth/potato-mesh" target="_blank">l5yth/potato-mesh</a>
+    <% if matrix_room && !matrix_room.empty? %>
+      — Meshtastic <%= site_name %> Matrix:
+      <a href="https://matrix.to/#/<%= matrix_room %>" target="_blank"><%= matrix_room %></a>
+    <% end %>
   </footer>
 
   <script>
@@ -141,8 +143,8 @@
     const REFRESH_MS = 60000;
     refreshInfo.textContent = `#MediumFast — auto-refresh every ${REFRESH_MS / 1000} seconds.`;
 
-    const MAP_CENTER = L.latLng(52.502889, 13.404194);
-    const MAX_NODE_DISTANCE_KM = 137;
+    const MAP_CENTER = L.latLng(<%= map_center_lat %>, <%= map_center_lon %>);
+    const MAX_NODE_DISTANCE_KM = <%= max_node_distance_km %>;
 
     const roleColors = Object.freeze({
       CLIENT: '#A8D5BA',
@@ -167,7 +169,7 @@
       attribution: '&copy; OpenStreetMap contributors &amp; Stadia Maps'
     });
     let tiles = lightTiles.addTo(map);
-    // Default view (Berlin center) until first data arrives
+    // Default view until first data arrives
     map.setView(MAP_CENTER, 10);
 
     const markersLayer = L.layerGroup().addTo(map);


### PR DESCRIPTION
## Summary
- make site name, map center and matrix room configurable via environment variables
- remove Berlin-specific references from tests and docs

## Testing
- `bundle exec ruby -c app.rb`
- `python -m py_compile data/mesh.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7e249f460832baaf4979e6c7e8bef