### PR TITLE
Convert boolean flags for SQLite binding

### DIFF
--- a/web/app.rb
+++ b/web/app.rb
@@ -95,6 +95,13 @@ def upsert_node(db, node_id, n)
   pt = nil if pt && pt > now
   lh = now if lh && lh > now
   lh = pt if pt && (!lh || lh < pt)
+  bool = ->(v) {
+    case v
+    when true then 1
+    when false then 0
+    else v
+    end
+  }
   row = [
     node_id,
     n["num"],
@@ -104,8 +111,8 @@ def upsert_node(db, node_id, n)
     user["hwModel"] || n["hwModel"],
     role,
     user["publicKey"],
-    user["isUnmessagable"],
-    n["isFavorite"],
+    bool.call(user["isUnmessagable"]),
+    bool.call(n["isFavorite"]),
     n["hopsAway"],
     n["snr"],
     lh,


### PR DESCRIPTION
## Summary
- Ensure `isUnmessagable` and `isFavorite` fields are converted to integers before inserting into SQLite

## Testing
- `bundle exec ruby -c app.rb`
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c7f736ba3c832b87216bab70013c4f