### PR TITLE
Log node object on snapshot update failure

### DIFF
--- a/data/mesh.py
+++ b/data/mesh.py
@@ -200,7 +200,12 @@ def main():
         try:
             nodes = getattr(iface, "nodes", {}) or {}
             for node_id, n in nodes.items():
-                upsert_node(node_id, n)
+                try:
+                    upsert_node(node_id, n)
+                except Exception as e:
+                    print(f"[warn] failed to update node snapshot for {node_id}: {e}")
+                    if DEBUG:
+                        print(f"[debug] node object: {n!r}")
         except Exception as e:
             print(f"[warn] failed to update node snapshot: {e}")
         stop.wait(SNAPSHOT_SECS)


### PR DESCRIPTION
## Summary
- Log node object when node snapshot update fails

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c80001d198832b9cf7f90c38b18997