### PR TITLE
Fix nested dataclass serialization for node snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.1.0
 
+* Fix nested dataclass serialization for node snapshots
 * Show daily node count in title and header by @l5yth in https://github.com/l5yth/potato-mesh/pull/49
 * Add daily date separators to chat log by @l5yth in https://github.com/l5yth/potato-mesh/pull/47
 * Feat: make frontend responsive for mobile by @l5yth in https://github.com/l5yth/potato-mesh/pull/46


### PR DESCRIPTION
## Summary
- recursively convert nested dataclasses and protobuf messages when preparing node snapshots
- update changelog entry

## Testing
- `python -m py_compile data/mesh.py`
- `pip install meshtastic` *(fails: Could not find a version that satisfies the requirement meshtastic)*

------
https://chatgpt.com/codex/tasks/task_e_68c808d5a674832b86e7ba68d0cac79a