### PR TITLE
style: condense node table

### DIFF
--- a/web/views/index.erb
+++ b/web/views/index.erb
@@ -25,8 +25,8 @@
     .meta { color:#555; margin-bottom:12px }
     .pill{ display:inline-block; padding:2px 8px; border-radius:999px; background:#eee; font-size:12px }
     #map { flex: 1; height: 60vh; border: 1px solid #ddd; border-radius: 8px; }
-    table { border-collapse: collapse; width: 100%; margin-top: var(--pad); }
-    th, td { border-bottom: 1px solid #ddd; padding: 6px; text-align: left; }
+    table { border-collapse: collapse; width: 100%; margin: 0; }
+    th, td { padding: 4px 6px; text-align: left; }
     th { position: sticky; top: 0; background: #fafafa; }
     .mono { font-family: ui-monospace, Menlo, Consolas, monospace; }
     .row { display: flex; gap: var(--pad); align-items: center; justify-content: space-between; }
@@ -57,7 +57,6 @@
     body.dark .pill { background: #444; }
     body.dark #map { border-color: #444; }
     body.dark #chat { border-color: #444; background: #222; color: #eee; }
-    body.dark th, body.dark td { border-bottom-color: #444; }
     body.dark th { background: #222; }
     body.dark button { background: #333; border-color: #444; color: #eee; }
     body.dark button:hover { background: #444; }


### PR DESCRIPTION
## Summary
- streamline node table styling
- remove table borders and margin for compact display

## Testing
- `ruby -c web/app.rb`
- `erb -x -T - web/views/index.erb | ruby -c`


------
https://chatgpt.com/codex/tasks/task_e_68c83ad9d7cc832b906dea23cb94cd14