### PR TITLE
Improve mobile layout

### DIFF
--- a/web/views/index.erb
+++ b/web/views/index.erb
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title><%= site_name %></title>
+  <% refresh_interval_seconds = 60 %>
 
   <!-- Leaflet CSS/JS (CDN) -->
   <link
@@ -36,6 +37,10 @@
     .chat-entry-msg { font-family: ui-monospace, Menlo, Consolas, monospace; }
     .chat-entry-date { font-family: ui-monospace, Menlo, Consolas, monospace; font-weight: bold; }
     .short-name { display:inline-block; border-radius:4px; padding:0 2px; }
+    .meta-info { display: flex; flex-direction: column; gap: 6px; align-items: flex-start; }
+    .subheading { margin: 0; font-size: 16px; font-weight: 500; color: #333; }
+    .refresh-info { margin: 0; color: #555; }
+    .refresh-actions { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
     .controls { display: flex; gap: 8px; align-items: center; }
     button { padding: 6px 10px; border: 1px solid #ccc; background: #fff; border-radius: 6px; cursor: pointer; }
     button:hover { background: #f6f6f6; }
@@ -46,14 +51,44 @@
     #map .leaflet-tile { filter: opacity(70%); }
     footer { position: fixed; bottom: 0; left: var(--pad); width: calc(100% - 2 * var(--pad)); background: #fafafa; border-top: 1px solid #ddd; text-align: center; font-size: 12px; padding: 4px 0; }
     @media (max-width: 768px) {
+      .row { flex-direction: column; align-items: stretch; gap: var(--pad); }
       .map-row { flex-direction: column; }
+      .controls { order: 2; flex-wrap: wrap; justify-content: flex-start; width: 100%; gap: 12px; }
+      .controls label { flex: 1 1 100%; }
+      .controls input[type="text"] { flex: 1 1 auto; min-width: 0; }
+      .controls button { align-self: flex-start; }
+      .meta-info { order: 1; width: 100%; }
+      .refresh-actions { flex-direction: column; align-items: flex-start; gap: 6px; }
       #map { order: 1; flex: none; max-width: 100%; height: 50vh; }
       #chat { order: 2; flex: none; max-width: 100%; height: 30vh; }
+      #nodes { font-size: 12px; }
+      #nodes th:nth-child(1),
+      #nodes td:nth-child(1),
+      #nodes th:nth-child(5),
+      #nodes td:nth-child(5),
+      #nodes th:nth-child(6),
+      #nodes td:nth-child(6),
+      #nodes th:nth-child(8),
+      #nodes td:nth-child(8),
+      #nodes th:nth-child(9),
+      #nodes td:nth-child(9),
+      #nodes th:nth-child(12),
+      #nodes td:nth-child(12),
+      #nodes th:nth-child(13),
+      #nodes td:nth-child(13),
+      #nodes th:nth-child(14),
+      #nodes td:nth-child(14),
+      #nodes th:nth-child(15),
+      #nodes td:nth-child(15) {
+        display: none;
+      }
     }
 
     /* Dark mode overrides */
     body.dark { background: #111; color: #eee; }
     body.dark .meta { color: #bbb; }
+    body.dark .subheading { color: #ddd; }
+    body.dark .refresh-info { color: #bbb; }
     body.dark .pill { background: #444; }
     body.dark #map { border-color: #444; }
     body.dark #chat { border-color: #444; background: #222; color: #eee; }
@@ -74,10 +109,13 @@
 <body>
   <h1><%= site_name %></h1>
   <div class="row meta">
-    <div>
-      <span id="refreshInfo"></span>
-      <button id="refreshBtn" type="button">Refresh now</button>
-      <span id="status" class="pill">loading…</span>
+    <div class="meta-info">
+      <p id="subHeading" class="subheading">Live data for <%= default_channel %> (<%= default_frequency %>)</p>
+      <p id="refreshInfo" class="refresh-info" aria-live="polite">Active nodes (hour/day/week): … — auto-refresh every <%= refresh_interval_seconds %> seconds.</p>
+      <div class="refresh-actions">
+        <button id="refreshBtn" type="button">Refresh now</button>
+        <span id="status" class="pill">loading…</span>
+      </div>
     </div>
     <div class="controls">
       <label><input type="checkbox" id="fitBounds" checked /> Auto-fit map</label>
@@ -132,6 +170,7 @@
     const headerEl = document.querySelector('h1');
     const chatEl = document.getElementById('chat');
     const refreshInfo = document.getElementById('refreshInfo');
+    const subHeadingEl = document.getElementById('subHeading');
     const baseTitle = document.title;
     let allNodes = [];
     const seenNodeIds = new Set();
@@ -139,8 +178,9 @@
     let lastChatDate;
     const NODE_LIMIT = 1000;
     const CHAT_LIMIT = 1000;
-    const REFRESH_MS = 60000;
-    refreshInfo.textContent = `<%= default_channel %> (<%= default_frequency %>) — auto-refresh every ${REFRESH_MS / 1000} seconds.`;
+    const REFRESH_MS = <%= refresh_interval_seconds * 1000 %>;
+    subHeadingEl.textContent = `Live data for <%= default_channel %> (<%= default_frequency %>)`;
+    refreshInfo.textContent = `Active nodes (hour/day/week): … — auto-refresh every ${REFRESH_MS / 1000} seconds.`;
 
     const MAP_CENTER = L.latLng(<%= map_center_lat %>, <%= map_center_lon %>);
     const MAX_NODE_DISTANCE_KM = <%= max_node_distance_km %>;
@@ -484,7 +524,7 @@
         const c = nodes.filter(n => n.last_heard && nowSec - Number(n.last_heard) <= w.secs).length;
         return `${c}/${w.label}`;
       }).join(', ');
-      refreshInfo.textContent = `<%= default_channel %> (<%= default_frequency %>) — active nodes: ${counts} — auto-refresh every ${REFRESH_MS / 1000} seconds.`;
+      refreshInfo.textContent = `Active nodes (hour/day/week): ${counts} — auto-refresh every ${REFRESH_MS / 1000} seconds.`;
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- restructure the secondary header so the sub heading and refresh status lead the layout on small screens
- tweak responsive styles so controls, map, and chat flow in the requested order on screens 768px wide or smaller
- simplify the mobile node table by hiding low-priority columns and share the refresh interval between HTML and script

## Testing
- not run (UI changes only)


------
https://chatgpt.com/codex/tasks/task_e_68c864755b30832b83e0428c0ad94192