### PR TITLE
Add RSpec smoke tests for app boot and database init

### DIFF
--- a/web/Gemfile
+++ b/web/Gemfile
@@ -4,3 +4,8 @@ gem "sinatra", "~> 4.0"
 gem "sqlite3", "~> 1.7"
 gem "rackup", "~> 2.2"
 gem "puma", "~> 7.0"
+
+group :test do
+  gem "rspec", "~> 3.12"
+  gem "rack-test", "~> 2.1"
+end

--- a/web/spec/app_spec.rb
+++ b/web/spec/app_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "sqlite3"
+
+RSpec.describe "Potato Mesh Sinatra app" do
+  let(:app) { Sinatra::Application }
+
+  describe "GET /" do
+    it "responds successfully" do
+      get "/"
+      expect(last_response).to be_ok
+    end
+  end
+
+  describe "database initialization" do
+    it "creates the schema when booting" do
+      expect(File).to exist(DB_PATH)
+
+      db = SQLite3::Database.new(DB_PATH, readonly: true)
+      tables = db.execute("SELECT name FROM sqlite_master WHERE type='table' AND name IN ('nodes','messages')").flatten
+
+      expect(tables).to include("nodes")
+      expect(tables).to include("messages")
+    ensure
+      db&.close
+    end
+  end
+end

--- a/web/spec/spec_helper.rb
+++ b/web/spec/spec_helper.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+require "fileutils"
+
+ENV["RACK_ENV"] = "test"
+
+SPEC_TMPDIR = Dir.mktmpdir("potato-mesh-spec-")
+ENV["MESH_DB"] = File.join(SPEC_TMPDIR, "mesh.db")
+
+require_relative "../app"
+
+require "rack/test"
+require "rspec"
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+
+  config.include Rack::Test::Methods
+
+  config.after(:suite) do
+    FileUtils.remove_entry(SPEC_TMPDIR) if File.directory?(SPEC_TMPDIR)
+  end
+end


### PR DESCRIPTION
## Summary
- add RSpec and rack-test as test dependencies
- configure the spec helper to boot the app with a temporary database
- add specs that hit the root endpoint and confirm the database schema is created during boot

## Testing
- bundle exec rspec *(fails: network restrictions prevent installing gems via Bundler)*

------
https://chatgpt.com/codex/tasks/task_e_68c900a59070832bb2069145a53e0a1c