### PR TITLE
Add Codecov upload step to Ruby workflow

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -31,3 +31,10 @@ jobs:
       run: bundle install
     - name: Run tests
       run: bundle exec rspec
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        fail_ci_if_error: false
+        flags: ruby-${{ matrix.ruby-version }}
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- add a Codecov upload step to the Ruby test workflow
- configure the upload step to tag results per Ruby version

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c91247ea04832b919acf3b7877ddce