### PR TITLE
Configure SimpleCov reporting for Codecov

### DIFF
--- a/web/Gemfile
+++ b/web/Gemfile
@@ -23,4 +23,6 @@ group :test do
   gem "rspec", "~> 3.12"
   gem "rack-test", "~> 2.1"
   gem "rufo", "~> 0.18.1"
+  gem "simplecov", "~> 0.22", require: false
+  gem "simplecov_json_formatter", "~> 0.1", require: false
 end

--- a/web/spec/spec_helper.rb
+++ b/web/spec/spec_helper.rb
@@ -14,6 +14,22 @@
 
 # frozen_string_literal: true
 
+require "simplecov"
+require "simplecov_json_formatter"
+
+SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new(
+  [
+    SimpleCov::Formatter::SimpleFormatter,
+    SimpleCov::Formatter::HTMLFormatter,
+    SimpleCov::Formatter::JSONFormatter,
+  ],
+)
+
+SimpleCov.start do
+  enable_coverage :branch
+  add_filter "/spec/"
+end
+
 require "tmpdir"
 require "fileutils"
 


### PR DESCRIPTION
## Summary
- add SimpleCov gems so the Sinatra app can generate coverage data
- initialize SimpleCov with HTML and JSON formatters for Codecov uploads and enable branch coverage

## Testing
- `bundle install` *(fails: Bundler cannot download gems in this environment)*
- `bundle exec rspec` *(fails: rspec executable missing because bundle install could not run)*

------
https://chatgpt.com/codex/tasks/task_e_68c916e8c6b0832b91c224c0064bbd59