### PR TITLE
Add JUnit test reporting to Ruby CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -30,7 +30,19 @@ jobs:
     - name: Set up dependencies 
       run: bundle install
     - name: Run tests
-      run: bundle exec rspec
+      run: |
+        mkdir -p tmp/test-results
+        bundle exec rspec \
+          --require rspec_junit_formatter \
+          --format progress \
+          --format RspecJunitFormatter \
+          --out tmp/test-results/rspec.xml
+    - name: Upload test results to Codecov
+      uses: codecov/test-results-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./web/tmp/test-results/rspec.xml
+        flags: ruby-${{ matrix.ruby-version }}
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5
       with:

--- a/web/Gemfile
+++ b/web/Gemfile
@@ -25,4 +25,5 @@ group :test do
   gem "rufo", "~> 0.18.1"
   gem "simplecov", "~> 0.22", require: false
   gem "simplecov_json_formatter", "~> 0.1", require: false
+  gem "rspec_junit_formatter", "~> 0.6", require: false
 end


### PR DESCRIPTION
## Summary
- add the rspec_junit_formatter gem so specs can emit JUnit output
- update the Ruby workflow to record specs in JUnit format and send the results to Codecov analytics

## Testing
- `bundle exec rspec --require rspec_junit_formatter --format progress --format RspecJunitFormatter --out tmp/test-results/rspec.xml` *(fails: missing gem executables until bundle install can reach rubygems.org)*

------
https://chatgpt.com/codex/tasks/task_e_68c919af8c10832ba0fb7713ecf8e46f