### PR TITLE
Add coverage for debug logging on messages without sender

### DIFF
--- a/web/app.rb
+++ b/web/app.rb
@@ -115,8 +115,8 @@ def query_messages(limit)
   rows.each do |r|
     if DEBUG && (r["from_id"].nil? || r["from_id"].to_s.empty?)
       raw = db.execute("SELECT * FROM messages WHERE id = ?", [r["id"]]).first
-      warn "[debug] messages row before join: #{raw.inspect}"
-      warn "[debug] row after join: #{r.inspect}"
+      Kernel.warn "[debug] messages row before join: #{raw.inspect}"
+      Kernel.warn "[debug] row after join: #{r.inspect}"
     end
     node = {}
     r.keys.each do |k|
@@ -126,7 +126,7 @@ def query_messages(limit)
     r["snr"] = r.delete("msg_snr")
     r["node"] = node unless node.empty?
     if DEBUG && (r["from_id"].nil? || r["from_id"].to_s.empty?)
-      warn "[debug] row after processing: #{r.inspect}"
+      Kernel.warn "[debug] row after processing: #{r.inspect}"
     end
   end
   rows

--- a/web/spec/app_spec.rb
+++ b/web/spec/app_spec.rb
@@ -509,13 +509,13 @@ RSpec.describe "Potato Mesh Sinatra app" do
         expect(last_response).to be_ok
 
         expect(Kernel).to have_received(:warn).with(
-          a_string_matching(/\[debug\] messages row before join: .*"id"=>#{message_id}/),
+          a_string_matching(/\[debug\] messages row before join: .*"id"\s*=>\s*#{message_id}/),
         )
         expect(Kernel).to have_received(:warn).with(
-          a_string_matching(/\[debug\] row after join: .*"id"=>#{message_id}/),
+          a_string_matching(/\[debug\] row after join: .*"id"\s*=>\s*#{message_id}/),
         )
         expect(Kernel).to have_received(:warn).with(
-          a_string_matching(/\[debug\] row after processing: .*"id"=>#{message_id}/),
+          a_string_matching(/\[debug\] row after processing: .*"id"\s*=>\s*#{message_id}/),
         )
 
         messages = JSON.parse(last_response.body)


### PR DESCRIPTION
## Summary
- add a spec that enables DEBUG mode and requests messages without a sender id
- assert that the debug warnings fire and the response still omits the sender field

## Testing
- bundle exec rspec *(fails: bundler: command not found: rspec; rubygems.org responded 403 when running bundle install)*

------
https://chatgpt.com/codex/tasks/task_e_68c91de47f40832bbf479b2ffd146797