### PR TITLE
Skip null identifiers when selecting packet fields

### DIFF
--- a/data/mesh.py
+++ b/data/mesh.py
@@ -109,7 +109,12 @@ def _iso(ts: int | float) -> str:
 
 
 def _first(d, *names, default=None):
-    """Return first present key from names (supports nested 'a.b' lookups)."""
+    """Return first non-empty key from names (supports nested 'a.b' lookups).
+
+    Keys that resolve to ``None`` or an empty string are skipped so callers can
+    provide multiple potential field names without accidentally capturing an
+    explicit ``null`` value.
+    """
 
     def _mapping_get(obj, key):
         if isinstance(obj, Mapping) and key in obj:
@@ -131,6 +136,10 @@ def _first(d, *names, default=None):
             if not ok:
                 break
         if ok:
+            if cur is None:
+                continue
+            if isinstance(cur, str) and cur == "":
+                continue
             return cur
     return default
 


### PR DESCRIPTION
## Summary
- skip `None`/empty string values when choosing between alternate packet fields so fallbacks like `from` are used
- document the helper's behavior to clarify it ignores explicit nulls

## Testing
- python -m compileall data

------
https://chatgpt.com/codex/tasks/task_e_68c92a75b184832bb1f91b944fe44212