### PR TITLE
Add Codecov reporting to Python CI

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -24,10 +24,24 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install black pytest meshtastic
+        pip install black pytest pytest-cov meshtastic
     - name: Lint with black
       run: |
         black --check ./
-    - name: Test with pytest
+    - name: Test with pytest and coverage
       run: |
-        pytest
+        mkdir -p reports
+        pytest --cov=data --cov-report=term --cov-report=xml:reports/python-coverage.xml --junitxml=reports/python-junit.xml
+    - name: Upload coverage to Codecov
+      if: always()
+      uses: codecov/codecov-action@v5
+      with:
+        files: reports/python-coverage.xml
+        flags: python-ingestor
+        name: python-ingestor
+    - name: Upload test results to Codecov
+      if: always()
+      uses: codecov/test-results-action@v1
+      with:
+        files: reports/python-junit.xml
+        flags: python-ingestor

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ Gemfile.lock
 
 # Python cache directories
 __pycache__/
+.coverage
+coverage.xml
+htmlcov/
+reports/


### PR DESCRIPTION
## Summary
- run pytest with coverage for the Python ingestor workflow and upload results to Codecov
- publish JUnit test results to Codecov Test Analytics
- ignore local coverage and test report artifacts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9334120b8832b8c301ec3ddcbab13