### PR TITLE
Add tests covering mesh helper edge cases

### DIFF
--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -339,7 +339,9 @@ def test_pkt_to_dict_handles_dict_and_proto(mesh_module, monkeypatch):
 def test_store_packet_dict_uses_top_level_channel(mesh_module, monkeypatch):
     mesh = mesh_module
     captured = []
-    monkeypatch.setattr(mesh, "_post_json", lambda path, payload: captured.append(payload))
+    monkeypatch.setattr(
+        mesh, "_post_json", lambda path, payload: captured.append(payload)
+    )
 
     packet = {
         "id": "789",
@@ -363,7 +365,9 @@ def test_store_packet_dict_uses_top_level_channel(mesh_module, monkeypatch):
 def test_store_packet_dict_handles_invalid_channel(mesh_module, monkeypatch):
     mesh = mesh_module
     captured = []
-    monkeypatch.setattr(mesh, "_post_json", lambda path, payload: captured.append(payload))
+    monkeypatch.setattr(
+        mesh, "_post_json", lambda path, payload: captured.append(payload)
+    )
 
     packet = {
         "id": 321,


### PR DESCRIPTION
## Summary
- add unit tests for mesh helper functions like `_get`, `_first`, `_post_json`, and `_pkt_to_dict`
- cover additional store_packet_dict scenarios including fallback channels and invalid data handling
- exercise error handling in `on_receive` and `_node_items_snapshot` iterable branch

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c9386a4090832b97eff1aa89602991