### PR TITLE
Fix message spec node lookup for numeric IDs

### DIFF
--- a/web/spec/app_spec.rb
+++ b/web/spec/app_spec.rb
@@ -582,7 +582,7 @@ RSpec.describe "Potato Mesh Sinatra app" do
           unless node_expected
             canonical_id = node_aliases[lookup_id.to_s]
             expect(canonical_id).not_to be_nil,
-                                      "node fixture missing for from_id #{lookup_id.inspect}"
+                                        "node fixture missing for from_id #{lookup_id.inspect}"
             node_expected = nodes_by_id.fetch(canonical_id)
           end
 


### PR DESCRIPTION
## Summary
- allow the GET /api/messages spec to look up expected node rows by either node id or numeric node number
- seed aliases from the node and message fixtures so numeric from_id values resolve to the canonical node id before assertions

## Testing
- bundle install *(fails: Bundler cannot reach rubygems.org and returns 403 Forbidden)*
- bundle exec rspec spec/app_spec.rb:525 *(skipped, Bundler reports `command not found: rspec` because the install step failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c9562b24f4832bbec48388f6e366a2