### PR TITLE
Prioritize node posts in queued API updates

### DIFF
--- a/data/mesh.py
+++ b/data/mesh.py
@@ -117,7 +117,9 @@ def _drain_post_queue():
         _post_json(path, payload)
 
 
-def _queue_post_json(path: str, payload: dict, *, priority: int = _DEFAULT_POST_PRIORITY):
+def _queue_post_json(
+    path: str, payload: dict, *, priority: int = _DEFAULT_POST_PRIORITY
+):
     """Queue a POST request and start processing if idle."""
 
     global _POST_QUEUE_ACTIVE

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -415,9 +415,7 @@ def test_post_queue_prioritises_nodes(mesh_module, monkeypatch):
 
     monkeypatch.setattr(mesh, "_post_json", record)
 
-    mesh._enqueue_post_json(
-        "/api/messages", {"id": 1}, mesh._MESSAGE_POST_PRIORITY
-    )
+    mesh._enqueue_post_json("/api/messages", {"id": 1}, mesh._MESSAGE_POST_PRIORITY)
     mesh._enqueue_post_json(
         "/api/nodes", {"!node": {"foo": "bar"}}, mesh._NODE_POST_PRIORITY
     )


### PR DESCRIPTION
## Summary
- add a shared POST queue that processes higher priority node updates before messages
- enqueue node upserts and stored messages with appropriate priorities
- extend the mesh tests to cover the queue, priority handling, and fixture cleanup

## Testing
- pytest tests/test_mesh.py

------
https://chatgpt.com/codex/tasks/task_e_68c99ba6365c832ba5b4687da3ef043c