### PR TITLE
Hide location columns on medium screens

### DIFF
--- a/web/views/index.erb
+++ b/web/views/index.erb
@@ -88,6 +88,19 @@
     .info-details dt { font-weight: 600; margin-top: 12px; color: #222; }
     .info-details dd { margin: 4px 0 0; }
     .info-details dd a { color: inherit; word-break: break-word; }
+    @media (max-width: 1280px) {
+      #nodes th:nth-child(12),
+      #nodes td:nth-child(12),
+      #nodes th:nth-child(13),
+      #nodes td:nth-child(13),
+      #nodes th:nth-child(14),
+      #nodes td:nth-child(14),
+      #nodes th:nth-child(15),
+      #nodes td:nth-child(15) {
+        display: none;
+      }
+    }
+
     @media (max-width: 768px) {
       .row { flex-direction: column; align-items: stretch; gap: var(--pad); }
       .map-row { flex-direction: column; }


### PR DESCRIPTION
## Summary
- hide the Latitude, Longitude, Altitude, and Last Position columns below 1280px to declutter the node table on smaller screens

## Testing
- bundle install *(fails: unable to download gems due to 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c9a03b6078832b9da35e3a895afa1a