### PR TITLE
Adjust python ingestor interval to 60 seconds

### DIFF
--- a/data/mesh.py
+++ b/data/mesh.py
@@ -35,7 +35,7 @@ from google.protobuf.message import Message as ProtoMessage
 
 # --- Config (env overrides) ---------------------------------------------------
 PORT = os.environ.get("MESH_SERIAL", "/dev/ttyACM0")
-SNAPSHOT_SECS = int(os.environ.get("MESH_SNAPSHOT_SECS", "30"))
+SNAPSHOT_SECS = int(os.environ.get("MESH_SNAPSHOT_SECS", "60"))
 CHANNEL_INDEX = int(os.environ.get("MESH_CHANNEL_INDEX", "0"))
 DEBUG = os.environ.get("DEBUG") == "1"
 INSTANCE = os.environ.get("POTATOMESH_INSTANCE", "").rstrip("/")

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -96,6 +96,12 @@ def mesh_module(monkeypatch):
     sys.modules.pop(module_name, None)
 
 
+def test_snapshot_interval_defaults_to_60_seconds(mesh_module):
+    mesh = mesh_module
+
+    assert mesh.SNAPSHOT_SECS == 60
+
+
 def test_node_to_dict_handles_nested_structures(mesh_module):
     mesh = mesh_module
 


### PR DESCRIPTION
## Summary
- update the Python ingestor's default snapshot interval to 60 seconds
- add a unit test to lock in the new polling cadence

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9b18fe9e0832bbacf2fcfc20d5106