### PR TITLE
fix: restore alpine build tooling for ingestor

### DIFF
--- a/data/Dockerfile
+++ b/data/Dockerfile
@@ -11,12 +11,18 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
-RUN apk add --no-cache \
-    tzdata \
-    curl
-
 COPY data/requirements.txt ./
-RUN python -m pip install --no-cache-dir -r requirements.txt
+RUN set -eux; \
+    apk add --no-cache \
+        tzdata \
+        curl; \
+    apk add --no-cache --virtual .build-deps \
+        gcc \
+        musl-dev \
+        linux-headers \
+        build-base; \
+    python -m pip install --no-cache-dir -r requirements.txt; \
+    apk del .build-deps
 
 COPY data/ .
 RUN addgroup -S potatomesh && \


### PR DESCRIPTION
## Summary
- restore the alpine build dependencies in the linux production stage so source-built wheels succeed on musl architectures
- remove the temporary toolchain after pip install to keep the final image size in check
