### PR TITLE
fix: retain alpine runtime libs after removing build deps

### DIFF
--- a/data/Dockerfile
+++ b/data/Dockerfile
@@ -15,7 +15,9 @@ COPY data/requirements.txt ./
 RUN set -eux; \
     apk add --no-cache \
         tzdata \
-        curl; \
+        curl \
+        libstdc++ \
+        libgcc; \
     apk add --no-cache --virtual .build-deps \
         gcc \
         musl-dev \


### PR DESCRIPTION
## Summary
- keep libstdc++ and libgcc installed outside the temporary build-deps virtual package so compiled wheels retain their runtime dependencies
