### PR TITLE
Add TCP support to Python ingestor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,12 @@ API_TOKEN=your-secure-api-token-here
 # - Windows (WSL): /dev/ttyS*
 MESH_SERIAL=/dev/ttyACM0
 
+# Optional Meshtastic TCP address (set to override serial connection)
+MESH_TCP_ADDRESS=
+
+# Optional Meshtastic TCP port override (default: 4403)
+MESH_TCP_PORT=
+
 # =============================================================================
 # SITE CUSTOMIZATION
 # =============================================================================

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -17,6 +17,7 @@ Edit `.env` file or run `./configure.sh` to set:
 - `API_TOKEN` - Required for ingestor authentication
 - `MESH_SERIAL` - Your Meshtastic device path (e.g., `/dev/ttyACM0`)
 - `MESH_TCP_ADDRESS` - Optional Meshtastic node IP (set to use TCP instead of serial)
+- `MESH_TCP_PORT` - Optional TCP port override (default: 4403)
 - `SITE_NAME` - Your mesh network name
 - `MAP_CENTER_LAT/LON` - Map center coordinates
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -16,6 +16,7 @@ Edit `.env` file or run `./configure.sh` to set:
 
 - `API_TOKEN` - Required for ingestor authentication
 - `MESH_SERIAL` - Your Meshtastic device path (e.g., `/dev/ttyACM0`)
+- `MESH_TCP_ADDRESS` - Optional Meshtastic node IP (set to use TCP instead of serial)
 - `SITE_NAME` - Your mesh network name
 - `MAP_CENTER_LAT/LON` - Map center coordinates
 

--- a/README.md
+++ b/README.md
@@ -88,8 +88,9 @@ accepts data through the API POST endpoints. Benefit is, here multiple nodes acr
 community can feed the dashboard with data. The web app handles messages and nodes
 by ID and there will be no duplication.
 
-For convenience, the directory `./data` contains a Python ingestor. It connects to a local
-Meshtastic node via serial port to gather nodes and messages seen by the node.
+For convenience, the directory `./data` contains a Python ingestor. It can connect to a
+Meshtastic node via serial port or the Meshtastic TCP API (WiFi/Ethernet) to gather nodes
+and messages seen by the node.
 
 ```bash
 pacman -S python
@@ -106,7 +107,7 @@ Check out `mesh.sh` ingestor script in the `./data` directory.
 
 ```bash
 POTATOMESH_INSTANCE=http://127.0.0.1:41447 API_TOKEN=1eb140fd-cab4-40be-b862-41c607762246 MESH_SERIAL=/dev/ttyACM0 DEBUG=1 ./mesh.sh
-Mesh daemon: nodes+messages → http://127.0.0.1 | port=41447 | channel=0
+Mesh daemon: nodes+messages → http://127.0.0.1 | port=/dev/ttyACM0 | channel=0
 [...]
 [debug] upserted node !849b7154 shortName='7154'
 [debug] upserted node !ba653ae8 shortName='3ae8'
@@ -116,7 +117,9 @@ Mesh daemon: nodes+messages → http://127.0.0.1 | port=41447 | channel=0
 
 Run the script with `POTATOMESH_INSTANCE` and `API_TOKEN` to keep updating
 node records and parsing new incoming messages. Enable debug output with `DEBUG=1`,
-specify the serial port with `MESH_SERIAL` (default `/dev/ttyACM0`), etc.
+specify the serial port with `MESH_SERIAL` (default `/dev/ttyACM0`), or set
+`MESH_TCP_ADDRESS` (optionally `MESH_TCP_PORT`) to connect to a node over the
+network instead.
 
 ## License
 

--- a/configure.sh
+++ b/configure.sh
@@ -130,6 +130,14 @@ if ! grep -q "^MESH_SERIAL=" .env; then
     echo "MESH_SERIAL=/dev/ttyACM0" >> .env
 fi
 
+if ! grep -q "^MESH_TCP_ADDRESS=" .env; then
+    echo "MESH_TCP_ADDRESS=" >> .env
+fi
+
+if ! grep -q "^MESH_TCP_PORT=" .env; then
+    echo "MESH_TCP_PORT=" >> .env
+fi
+
 if ! grep -q "^DEBUG=" .env; then
     echo "DEBUG=0" >> .env
 fi

--- a/data/Dockerfile
+++ b/data/Dockerfile
@@ -33,6 +33,8 @@ RUN addgroup -S potatomesh && \
 USER potatomesh
 
 ENV MESH_SERIAL=/dev/ttyACM0 \
+    MESH_TCP_ADDRESS="" \
+    MESH_TCP_PORT="" \
     MESH_SNAPSHOT_SECS=60 \
     MESH_CHANNEL_INDEX=0 \
     DEBUG=0 \
@@ -59,6 +61,8 @@ COPY data/ .
 USER ContainerUser
 
 ENV MESH_SERIAL=/dev/ttyACM0 \
+    MESH_TCP_ADDRESS="" \
+    MESH_TCP_PORT="" \
     MESH_SNAPSHOT_SECS=60 \
     MESH_CHANNEL_INDEX=0 \
     DEBUG=0 \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
     container_name: potatomesh-ingestor
     environment:
       - MESH_SERIAL=${MESH_SERIAL:-/dev/ttyACM0}
+      - MESH_TCP_ADDRESS=${MESH_TCP_ADDRESS:-}
+      - MESH_TCP_PORT=${MESH_TCP_PORT:-}
       - MESH_SNAPSHOT_SECS=${MESH_SNAPSHOT_SECS:-60}
       - MESH_CHANNEL_INDEX=${MESH_CHANNEL_INDEX:-0}
       - POTATOMESH_INSTANCE=${POTATOMESH_INSTANCE:-http://web:41447}

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -50,9 +50,7 @@ def mesh_module(monkeypatch):
     monkeypatch.setitem(
         sys.modules, "meshtastic.serial_interface", serial_interface_mod
     )
-    monkeypatch.setitem(
-        sys.modules, "meshtastic.tcp_interface", tcp_interface_mod
-    )
+    monkeypatch.setitem(sys.modules, "meshtastic.tcp_interface", tcp_interface_mod)
 
     # Stub pubsub.pub
     pubsub_mod = types.ModuleType("pubsub")
@@ -566,4 +564,14 @@ def test_create_interface_raises_for_invalid_port_override(mesh_module):
     mesh.TCP_PORT_RAW = "invalid"
 
     with pytest.raises(ValueError):
+        mesh._create_interface()
+
+
+def test_create_interface_requires_tcp_module(mesh_module):
+    mesh = mesh_module
+    mesh.TCP_ADDRESS = "192.0.2.6"
+    mesh.TCP_PORT_RAW = ""
+    mesh.TCPInterface = None
+
+    with pytest.raises(RuntimeError):
         mesh._create_interface()


### PR DESCRIPTION
## Summary
- allow the Python ingestor to connect via Meshtastic TCP by parsing new MESH_TCP_* settings and building the proper interface
- surface the connection type in startup logs and default Docker environment variables
- document the new configuration options and add unit tests covering serial vs TCP interface selection and error handling
