### PR TITLE
Support mock serial interface in CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -130,6 +130,7 @@ jobs:
         docker run --rm --name ingestor-test \
           -e POTATOMESH_INSTANCE=http://localhost:41447 \
           -e API_TOKEN=test-token \
+          -e MESH_SERIAL=mock \
           -e DEBUG=1 \
           ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-ingestor-linux-amd64:${{ steps.version.outputs.version }} &
         sleep 5

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -102,6 +102,33 @@ def test_snapshot_interval_defaults_to_60_seconds(mesh_module):
     assert mesh.SNAPSHOT_SECS == 60
 
 
+@pytest.mark.parametrize("value", ["mock", "Mock", " disabled "])
+def test_create_serial_interface_allows_mock(mesh_module, value):
+    mesh = mesh_module
+
+    iface = mesh._create_serial_interface(value)
+
+    assert isinstance(iface.nodes, dict)
+    iface.close()
+
+
+def test_create_serial_interface_uses_serial_module(mesh_module, monkeypatch):
+    mesh = mesh_module
+    created = {}
+    sentinel = object()
+
+    def fake_interface(*, devPath):
+        created["devPath"] = devPath
+        return SimpleNamespace(nodes={"!foo": sentinel}, close=lambda: None)
+
+    monkeypatch.setattr(mesh, "SerialInterface", fake_interface)
+
+    iface = mesh._create_serial_interface("/dev/ttyTEST")
+
+    assert created["devPath"] == "/dev/ttyTEST"
+    assert iface.nodes == {"!foo": sentinel}
+
+
 def test_node_to_dict_handles_nested_structures(mesh_module):
     mesh = mesh_module
 


### PR DESCRIPTION
## Summary
- allow the ingestor to fall back to a dummy serial interface when MESH_SERIAL requests a mock device
- exercise the new mock path in unit tests and ensure the real SerialInterface remains used for real ports
- run the release test container with MESH_SERIAL=mock so it can start without hardware access
