### PR TITLE
Define docker compose network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,3 +69,7 @@ volumes:
   potatomesh_logs:
     driver: local
 
+networks:
+  potatomesh-network:
+    driver: bridge
+


### PR DESCRIPTION
## Summary
- add an explicit `potatomesh-network` definition so the web and ingestor services reference a defined network
- ref #144 