### PR TITLE
Derive SEO metadata from existing config values

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ The web app can be configured with environment variables (defaults shown):
 * `MAX_NODE_DISTANCE_KM` - hide nodes farther than this distance from the center (default: `137`)
 * `MATRIX_ROOM` - matrix room id for a footer link (default: `#meshtastic-berlin:matrix.org`)
 
+The application derives SEO-friendly document titles, descriptions, and social
+preview tags from these existing configuration values and reuses the bundled
+logo for Open Graph and Twitter cards.
+
 Example:
 
 ```bash

--- a/web/spec/app_spec.rb
+++ b/web/spec/app_spec.rb
@@ -189,6 +189,23 @@ RSpec.describe "Potato Mesh Sinatra app" do
       get "/"
       expect(last_response.body).to include("#{APP_VERSION}")
     end
+
+    it "includes SEO metadata from configuration" do
+      stub_const("SITE_NAME", "Spec Mesh Title")
+      stub_const("DEFAULT_CHANNEL", "#SpecChannel")
+      stub_const("DEFAULT_FREQUENCY", "915MHz")
+      stub_const("MAX_NODE_DISTANCE_KM", 120.5)
+      stub_const("MATRIX_ROOM", " #spec-room:example.org ")
+
+      expected_description = "Live Meshtastic mesh map for Spec Mesh Title on #SpecChannel (915MHz). Track nodes, messages, and coverage in real time. Shows nodes within roughly 120.5 km of the map center. Join the community in #spec-room:example.org on Matrix."
+
+      get "/"
+
+      expect(last_response.body).to include(%(meta name="description" content="#{expected_description}" />))
+      expect(last_response.body).to include('<meta property="og:title" content="Spec Mesh Title" />')
+      expect(last_response.body).to include('<meta property="og:site_name" content="Spec Mesh Title" />')
+      expect(last_response.body).to include('<meta name="twitter:image" content="http://example.org/potatomesh-logo.svg" />')
+    end
   end
 
   describe "database initialization" do

--- a/web/views/index.erb
+++ b/web/views/index.erb
@@ -20,7 +20,32 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title><%= site_name %></title>
+  <% meta_title_html = Rack::Utils.escape_html(meta_title) %>
+  <% meta_name_html = Rack::Utils.escape_html(meta_name) %>
+  <% meta_description_html = Rack::Utils.escape_html(meta_description) %>
+  <% request_path = request.path.to_s.empty? ? "/" : request.path %>
+  <% canonical_url = "#{request.base_url}#{request_path}" %>
+  <% canonical_html = Rack::Utils.escape_html(canonical_url) %>
+  <% logo_url = "#{request.base_url}/potatomesh-logo.svg" %>
+  <% logo_url_html = Rack::Utils.escape_html(logo_url) %>
+  <% logo_alt_html = Rack::Utils.escape_html("#{meta_name} logo") %>
+  <title><%= meta_title_html %></title>
+  <meta name="application-name" content="<%= meta_name_html %>" />
+  <meta name="apple-mobile-web-app-title" content="<%= meta_name_html %>" />
+  <meta name="description" content="<%= meta_description_html %>" />
+  <link rel="canonical" href="<%= canonical_html %>" />
+  <meta property="og:title" content="<%= meta_title_html %>" />
+  <meta property="og:site_name" content="<%= meta_name_html %>" />
+  <meta property="og:description" content="<%= meta_description_html %>" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="<%= canonical_html %>" />
+  <meta property="og:image" content="<%= logo_url_html %>" />
+  <meta property="og:image:alt" content="<%= logo_alt_html %>" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="<%= meta_title_html %>" />
+  <meta name="twitter:description" content="<%= meta_description_html %>" />
+  <meta name="twitter:image" content="<%= logo_url_html %>" />
+  <meta name="twitter:image:alt" content="<%= logo_alt_html %>" />
   <link rel="icon" type="image/svg+xml" href="/potatomesh-logo.svg" />
   <% refresh_interval_seconds = 60 %>
   <% tile_filter_light = "grayscale(1) saturate(0) brightness(0.92) contrast(1.05)" %>


### PR DESCRIPTION
## Summary
- remove the META_* environment variables from the sample configuration, setup script, and Docker manifests
- derive the SEO page title, description, and social card metadata from the configured site values while reusing the bundled logo image
- document that SEO tags are generated from the existing configuration and cover the behavior in the request spec
