### PR TITLE
Add support for NODEINFO_APP packets

### DIFF
--- a/data/mesh.py
+++ b/data/mesh.py
@@ -674,9 +674,7 @@ def store_nodeinfo_packet(packet: dict, decoded: Mapping):
     if node_info and "is_ignored" in node_info_fields:
         node_payload["isIgnored"] = bool(node_info.is_ignored)
     if node_info and "is_key_manually_verified" in node_info_fields:
-        node_payload["isKeyManuallyVerified"] = bool(
-            node_info.is_key_manually_verified
-        )
+        node_payload["isKeyManuallyVerified"] = bool(node_info.is_key_manually_verified)
 
     metrics = _nodeinfo_metrics_dict(node_info)
     decoded_metrics = decoded.get("deviceMetrics")
@@ -699,14 +697,15 @@ def store_nodeinfo_packet(packet: dict, decoded: Mapping):
         except (TypeError, ValueError):
             pass
 
-    _queue_post_json("/api/nodes", {node_id: node_payload}, priority=_NODE_POST_PRIORITY)
+    _queue_post_json(
+        "/api/nodes", {node_id: node_payload}, priority=_NODE_POST_PRIORITY
+    )
 
     if DEBUG:
         short = None
         if isinstance(user_dict, Mapping):
             short = user_dict.get("shortName")
         print(f"[debug] stored nodeinfo for {node_id} shortName={short!r}")
-
 
 
 def store_packet_dict(p: dict):

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -21,7 +21,9 @@ def mesh_module(monkeypatch):
     except Exception:  # pragma: no cover - dependency may be unavailable in CI
         real_meshtastic = None
 
-    real_protobuf = getattr(real_meshtastic, "protobuf", None) if real_meshtastic else None
+    real_protobuf = (
+        getattr(real_meshtastic, "protobuf", None) if real_meshtastic else None
+    )
 
     # Stub meshtastic.serial_interface.SerialInterface
     serial_interface_mod = types.ModuleType("meshtastic.serial_interface")
@@ -373,6 +375,8 @@ def test_store_packet_dict_nodeinfo_uses_from_id_when_user_missing(
     assert node_entry["num"] == 0x01020304
     assert node_entry["lastHeard"] == 200
     assert node_entry["snr"] == pytest.approx(1.5)
+
+
 def test_store_packet_dict_ignores_non_text(mesh_module, monkeypatch):
     mesh = mesh_module
     captured = []


### PR DESCRIPTION
## Summary
- extend the mesh ingestor to decode NODEINFO_APP payloads, normalise node identifiers, and forward metrics/position updates to the node API
- harden protobuf conversions to tolerate dummy proto objects during testing
- add coverage for NODEINFO_APP handling and load real protobuf helpers when available in the test harness

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d287e03e38832b9f6568691d15705d