### PR TITLE
Move lint checks after tests in CI

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -22,9 +22,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install black pytest pytest-cov meshtastic
-    - name: Lint with black
-      run: |
-        black --check ./
     - name: Test with pytest and coverage
       run: |
         mkdir -p reports
@@ -45,3 +42,6 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: reports/python-junit.xml
         flags: python-ingestor
+    - name: Lint with black
+      run: |
+        black --check ./

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -29,8 +29,6 @@ jobs:
         working-directory: ./web
     - name: Set up dependencies
       run: bundle install
-    - name: Run rufo
-      run: bundle exec rufo --check .
     - name: Run tests
       run: |
         mkdir -p tmp/test-results
@@ -53,3 +51,5 @@ jobs:
         flags: ruby-${{ matrix.ruby-version }}
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    - name: Run rufo
+      run: bundle exec rufo --check .


### PR DESCRIPTION
## Summary
- run the Python workflow's test suite before invoking the black formatting check
- execute the Ruby workflow's tests and reporting steps before running rufo
- fix #164 