### PR TITLE
Update role colors and ordering for firmware 2.7.10

### DIFF
--- a/web/views/index.erb
+++ b/web/views/index.erb
@@ -545,28 +545,31 @@
     const MAP_CENTER = L.latLng(<%= map_center_lat %>, <%= map_center_lon %>);
     const MAX_NODE_DISTANCE_KM = <%= max_node_distance_km %>;
 
+    // Firmware 2.7.10 / Android 2.7.0 roles and colors (see issue #177)
     const roleColors = Object.freeze({
-      CLIENT: '#A8D5BA',
-      CLIENT_HIDDEN: '#B8DCA9',
-      CLIENT_MUTE: '#D2E3A2',
-      TRACKER: '#E8E6A1',
-      SENSOR: '#F4E3A3',
-      LOST_AND_FOUND: '#F9D4A6',
+      CLIENT_HIDDEN: '#A8D5BA',
+      SENSOR: '#B8DCA9',
+      TRACKER: '#D2E3A2',
+      CLIENT_MUTE: '#E8E6A1',
+      CLIENT: '#F4E3A3',
+      CLIENT_BASE: '#F9D4A6',
       REPEATER: '#F7B7A3',
       ROUTER_LATE: '#F29AA3',
-      ROUTER: '#E88B94'
+      ROUTER: '#E88B94',
+      LOST_AND_FOUND: '#A3C6E8'
     });
 
     const roleRenderOrder = Object.freeze({
-      CLIENT: 1,
-      CLIENT_HIDDEN: 2,
-      CLIENT_MUTE: 3,
-      TRACKER: 4,
-      SENSOR: 5,
-      LOST_AND_FOUND: 6,
+      CLIENT_HIDDEN: 1,
+      SENSOR: 2,
+      TRACKER: 3,
+      CLIENT_MUTE: 4,
+      CLIENT: 5,
+      CLIENT_BASE: 6,
       REPEATER: 7,
       ROUTER_LATE: 8,
-      ROUTER: 9
+      ROUTER: 9,
+      LOST_AND_FOUND: 10
     });
 
     const activeRoleFilters = new Set();


### PR DESCRIPTION
## Summary
- update role colors and legend ordering to match firmware 2.7.10 and Android app 2.7.0
- document the source of the palette in the UI script

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68d676915058832b8e7bbfe4117e8d5d