### PR TITLE
Populate chat metadata for unknown nodes

### DIFF
--- a/web/app.rb
+++ b/web/app.rb
@@ -598,16 +598,21 @@ def ensure_unknown_node(db, node_ref, fallback_num = nil)
   return if existing
 
   long_name = "Meshtastic #{short_id}"
+  now = Time.now.to_i
+  inserted = false
 
   with_busy_retry do
     db.execute(
       <<~SQL,
-      INSERT OR IGNORE INTO nodes(node_id,num,short_name,long_name,role)
-      VALUES (?,?,?,?,?)
+      INSERT OR IGNORE INTO nodes(node_id,num,short_name,long_name,role,last_heard,first_heard)
+      VALUES (?,?,?,?,?,?,?)
     SQL
-      [node_id, node_num, short_id, long_name, "CLIENT_HIDDEN"],
+      [node_id, node_num, short_id, long_name, "CLIENT_HIDDEN", now, now],
     )
+    inserted = db.changes.positive?
   end
+
+  inserted
 end
 
 # Insert or update a node row with the most recent metrics.


### PR DESCRIPTION
## Summary
- ensure_unknown_node now records first/last heard timestamps when inserting placeholder nodes so they appear in the chat log
- return whether the placeholder insert succeeded and cover the behavior with new specs

## Testing
- bundle exec rspec *(fails: Bundler cannot install gems due to 403 Forbidden from rubygems.org)*

------
https://chatgpt.com/codex/tasks/task_e_68d686ea39bc832b9ac8eec3c2df3e22