### PR TITLE
Update role color theme to latest palette

### DIFF
--- a/web/views/index.erb
+++ b/web/views/index.erb
@@ -547,16 +547,16 @@
 
     // Firmware 2.7.10 / Android 2.7.0 roles and colors (see issue #177)
     const roleColors = Object.freeze({
-      CLIENT_HIDDEN: '#A8D5BA',
-      SENSOR: '#B8DCA9',
-      TRACKER: '#D2E3A2',
+      CLIENT_HIDDEN: '#A9CBE8',
+      SENSOR: '#A8D5BA',
+      TRACKER: '#B9DFAC',
       CLIENT_MUTE: '#E8E6A1',
-      CLIENT: '#F4E3A3',
-      CLIENT_BASE: '#F9D4A6',
+      CLIENT: '#CDE7A9',
+      CLIENT_BASE: '#F6D0A6',
       REPEATER: '#F7B7A3',
       ROUTER_LATE: '#F29AA3',
       ROUTER: '#E88B94',
-      LOST_AND_FOUND: '#A3C6E8'
+      LOST_AND_FOUND: '#C3A8E8'
     });
 
     const roleRenderOrder = Object.freeze({


### PR DESCRIPTION
## Summary
- update the role color definitions in the map UI to match the latest palette

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d69c9b2e48832b9006aa7eddee1ad3