### PR TITLE
Update node last seen when ingesting encrypted messages

### DIFF
--- a/web/spec/app_spec.rb
+++ b/web/spec/app_spec.rb
@@ -1004,6 +1004,13 @@ RSpec.describe "Potato Mesh Sinatra app" do
         expect(row["to_id"]).to eq(receiver_id)
         expect(row["text"]).to be_nil
         expect(row["encrypted"]).to eq(encrypted_b64)
+
+        node_row = db.get_first_row(
+          "SELECT last_heard FROM nodes WHERE node_id = ?",
+          [sender_id],
+        )
+
+        expect(node_row["last_heard"]).to eq(reference_time.to_i)
       end
 
       get "/api/messages"


### PR DESCRIPTION
## Summary
- refresh a node's last_heard timestamp when an encrypted message is stored
- extend the encrypted message spec to verify the sender's last seen time is updated

## Testing
- bundle exec rspec spec/app_spec.rb:929 *(fails: rspec gem unavailable; Bundler install blocked by 403 from rubygems.org)*

------
https://chatgpt.com/codex/tasks/task_e_68d924814b7c832bbdcaf551bf34601e