### PR TITLE
Add private mode toggle for chat visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The web app can be configured with environment variables (defaults shown):
 * `MAP_CENTER_LAT` / `MAP_CENTER_LON` - default map center coordinates (default: `52.502889` / `13.404194`)
 * `MAX_NODE_DISTANCE_KM` - hide nodes farther than this distance from the center (default: `137`)
 * `MATRIX_ROOM` - matrix room id for a footer link (default: `#meshtastic-berlin:matrix.org`)
+* `PRIVATE` - set to `1` to hide chat history, suppress the `/api/messages` endpoint, and filter hidden placeholder clients
 
 The application derives SEO-friendly document titles, descriptions, and social
 preview tags from these existing configuration values and reuses the bundled
@@ -71,7 +72,7 @@ The web app contains an API:
 
 * GET `/api/nodes?limit=100` - returns the latest 100 nodes reported to the app
 * GET `/api/positions?limit=100` - returns the latest 100 position data
-* GET `/api/messages?limit=100` - returns the latest 100 messages
+* GET `/api/messages?limit=100` - returns the latest 100 messages (disabled when `PRIVATE=1`)
 * POST `/api/nodes` - upserts nodes provided as JSON object mapping node ids to node data (requires `Authorization: Bearer <API_TOKEN>`)
 * POST `/api/positions` - appends positions provided as a JSON object or array (requires `Authorization: Bearer <API_TOKEN>`)
 * POST `/api/messages` - appends messages provided as a JSON object or array (requires `Authorization: Bearer <API_TOKEN>`)

--- a/web/views/index.erb
+++ b/web/views/index.erb
@@ -515,7 +515,9 @@ var(--fg); }
   </div>
 
   <div class="map-row">
-    <div id="chat" aria-label="Chat log"></div>
+    <% unless private_mode %>
+      <div id="chat" aria-label="Chat log"></div>
+    <% end %>
     <div id="map" role="region" aria-label="Nodes map"></div>
   </div>
 
@@ -560,6 +562,7 @@ var(--fg); }
   </footer>
 
   <script>
+    const PRIVATE_MODE = <%= private_mode ? "true" : "false" %>;
     const statusEl = document.getElementById('status');
     const fitBoundsEl = document.getElementById('fitBounds');
     const autoRefreshEl = document.getElementById('autoRefresh');
@@ -576,7 +579,7 @@ var(--fg); }
     const titleEl = document.querySelector('title');
     const headerEl = document.querySelector('h1');
     const headerTitleTextEl = headerEl ? headerEl.querySelector('.site-title-text') : null;
-    const chatEl = document.getElementById('chat');
+    const chatEl = PRIVATE_MODE ? null : document.getElementById('chat');
     const refreshInfo = document.getElementById('refreshInfo');
     const baseTitle = document.title;
     const nodesTable = document.getElementById('nodes');
@@ -1541,11 +1544,15 @@ var(--fg); }
         const nodes = await fetchNodes();
         nodes.forEach(applyNodeNameFallback);
         computeDistances(nodes);
-        const messages = await fetchMessages();
-        messages.forEach(message => {
-          if (message && message.node) applyNodeNameFallback(message.node);
-        });
-        renderChatLog(nodes, messages);
+        if (!PRIVATE_MODE) {
+          const messages = await fetchMessages();
+          messages.forEach(message => {
+            if (message && message.node) applyNodeNameFallback(message.node);
+          });
+          renderChatLog(nodes, messages);
+        } else {
+          renderChatLog(nodes, []);
+        }
         allNodes = nodes;
         applyFilter();
         statusEl.textContent = 'updated ' + new Date().toLocaleTimeString();


### PR DESCRIPTION
## Summary
- add a PRIVATE environment flag to hide chat endpoints and filter hidden placeholder clients
- update the frontend to skip rendering chat UI and fetching messages when private mode is enabled
- document the new PRIVATE option and cover the behaviour with dedicated specs
- fix #194 