### PR TITLE
Add private mode to hide chat and message APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The web app can be configured with environment variables (defaults shown):
 * `MAP_CENTER_LAT` / `MAP_CENTER_LON` - default map center coordinates (default: `52.502889` / `13.404194`)
 * `MAX_NODE_DISTANCE_KM` - hide nodes farther than this distance from the center (default: `137`)
 * `MATRIX_ROOM` - matrix room id for a footer link (default: `#meshtastic-berlin:matrix.org`)
+* `PRIVATE` - set to `1` to hide the chat UI, disable message APIs, and exclude hidden clients (default: unset)
 
 The application derives SEO-friendly document titles, descriptions, and social
 preview tags from these existing configuration values and reuses the bundled
@@ -72,10 +73,10 @@ The web app contains an API:
 
 * GET `/api/nodes?limit=100` - returns the latest 100 nodes reported to the app
 * GET `/api/positions?limit=100` - returns the latest 100 position data
-* GET `/api/messages?limit=100` - returns the latest 100 messages
+* GET `/api/messages?limit=100` - returns the latest 100 messages (disabled when `PRIVATE=1`)
 * POST `/api/nodes` - upserts nodes provided as JSON object mapping node ids to node data (requires `Authorization: Bearer <API_TOKEN>`)
 * POST `/api/positions` - appends positions provided as a JSON object or array (requires `Authorization: Bearer <API_TOKEN>`)
-* POST `/api/messages` - appends messages provided as a JSON object or array (requires `Authorization: Bearer <API_TOKEN>`)
+* POST `/api/messages` - appends messages provided as a JSON object or array (requires `Authorization: Bearer <API_TOKEN>`; disabled when `PRIVATE=1`)
 
 The `API_TOKEN` environment variable must be set to a non-empty value and match the token supplied in the `Authorization` header for `POST` requests.
 

--- a/web/app.rb
+++ b/web/app.rb
@@ -209,10 +209,10 @@ def meta_description
   end
 
   activity_sentence = if private_mode?
-    "Track nodes and coverage in real time."
-  else
-    "Track nodes, messages, and coverage in real time."
-  end
+      "Track nodes and coverage in real time."
+    else
+      "Track nodes, messages, and coverage in real time."
+    end
 
   sentences = [summary, activity_sentence]
   if (distance = sanitized_max_distance_km)

--- a/web/spec/app_spec.rb
+++ b/web/spec/app_spec.rb
@@ -1368,9 +1368,9 @@ RSpec.describe "Potato Mesh Sinatra app" do
       expect(last_response).to be_ok
       body = last_response.body
       expect(body).not_to include('<div id="chat"')
-      expect(body).to include('const CHAT_ENABLED = false;')
-      expect(body).not_to include('Track nodes, messages, and coverage in real time.')
-      expect(body).to include('Track nodes and coverage in real time.')
+      expect(body).to include("const CHAT_ENABLED = false;")
+      expect(body).not_to include("Track nodes, messages, and coverage in real time.")
+      expect(body).to include("Track nodes and coverage in real time.")
     end
   end
 

--- a/web/views/index.erb
+++ b/web/views/index.erb
@@ -564,7 +564,9 @@ var(--fg); }
   </div>
 
   <div class="map-row">
-    <div id="chat" aria-label="Chat log"></div>
+    <% unless private_mode %>
+      <div id="chat" aria-label="Chat log"></div>
+    <% end %>
     <div id="map" role="region" aria-label="Nodes map"></div>
   </div>
 
@@ -658,6 +660,7 @@ var(--fg); }
     const CHAT_LIMIT = 1000;
     const CHAT_RECENT_WINDOW_SECONDS = 7 * 24 * 60 * 60;
     const REFRESH_MS = <%= refresh_interval_seconds * 1000 %>;
+    const CHAT_ENABLED = <%= private_mode ? "false" : "true" %>;
     refreshInfo.textContent = `<%= default_channel %> (<%= default_frequency %>) — active nodes: …`;
 
     let refreshTimer = null;
@@ -1206,6 +1209,7 @@ var(--fg); }
         const itemsContainer = L.DomUtil.create('div', 'legend-items', div);
         legendRoleButtons.clear();
         for (const [role, color] of Object.entries(roleColors)) {
+          if (!CHAT_ENABLED && role === 'CLIENT_HIDDEN') continue;
           const item = L.DomUtil.create('button', 'legend-item', itemsContainer);
           item.type = 'button';
           item.setAttribute('aria-pressed', 'false');
@@ -1526,7 +1530,7 @@ var(--fg); }
     }
 
     function renderChatLog(nodes, messages) {
-      if (!chatEl) return;
+      if (!CHAT_ENABLED || !chatEl) return;
       const entries = [];
       for (const n of nodes || []) {
         entries.push({ type: 'node', ts: n.first_heard ?? 0, item: n });
@@ -1649,6 +1653,7 @@ var(--fg); }
     }
 
     async function fetchMessages(limit = NODE_LIMIT) {
+      if (!CHAT_ENABLED) return [];
       const r = await fetch(`/api/messages?limit=${limit}`, { cache: 'no-store' });
       if (!r.ok) throw new Error('HTTP ' + r.status);
       return r.json();
@@ -1815,10 +1820,13 @@ var(--fg); }
         const nodes = await fetchNodes();
         nodes.forEach(applyNodeNameFallback);
         computeDistances(nodes);
-        const messages = await fetchMessages();
-        messages.forEach(message => {
-          if (message && message.node) applyNodeNameFallback(message.node);
-        });
+        let messages = [];
+        if (CHAT_ENABLED) {
+          messages = await fetchMessages();
+          messages.forEach(message => {
+            if (message && message.node) applyNodeNameFallback(message.node);
+          });
+        }
         renderChatLog(nodes, messages);
         allNodes = nodes;
         applyFilter();


### PR DESCRIPTION
## Summary
- add a PRIVATE mode flag that removes chat UI content, disables the message API endpoints, and updates metadata copy
- filter hidden client nodes from API responses while wiring the private-mode flag to the frontend so chat fetches are skipped
- document the new PRIVATE environment variable and cover the behaviour with new RSpec examples
- fix #194 