### PR TITLE
Stop repeating ingestor node info snapshot and timestamp debug logs

### DIFF
--- a/data/mesh.py
+++ b/data/mesh.py
@@ -1444,9 +1444,7 @@ def main():
                 nodes = getattr(iface, "nodes", {}) or {}
                 node_items = _node_items_snapshot(nodes)
                 if node_items is None:
-                    _debug_log(
-                        "skipping node snapshot; nodes changed during iteration"
-                    )
+                    _debug_log("skipping node snapshot; nodes changed during iteration")
                 else:
                     processed_snapshot_item = False
                     for node_id, n in node_items:
@@ -1468,9 +1466,11 @@ def main():
                 stop.wait(retry_delay)
                 if _RECONNECT_MAX_DELAY_SECS > 0:
                     retry_delay = min(
-                        retry_delay * 2
-                        if retry_delay
-                        else _RECONNECT_INITIAL_DELAY_SECS,
+                        (
+                            retry_delay * 2
+                            if retry_delay
+                            else _RECONNECT_INITIAL_DELAY_SECS
+                        ),
                         _RECONNECT_MAX_DELAY_SECS,
                     )
                 continue

--- a/data/mesh.py
+++ b/data/mesh.py
@@ -1448,7 +1448,9 @@ def main():
                         "skipping node snapshot; nodes changed during iteration"
                     )
                 else:
+                    processed_snapshot_item = False
                     for node_id, n in node_items:
+                        processed_snapshot_item = True
                         try:
                             upsert_node(node_id, n)
                         except Exception as e:
@@ -1457,7 +1459,8 @@ def main():
                             )
                             if DEBUG:
                                 _debug_log(f"node object: {n!r}")
-                    initial_snapshot_sent = True
+                    if processed_snapshot_item:
+                        initial_snapshot_sent = True
             except Exception as e:
                 print(f"[warn] failed to update node snapshot: {e}")
                 _close_interface(iface)


### PR DESCRIPTION
## Summary
- add a reusable debug helper that prefixes log lines with a UTC timestamp
- only run the initial node snapshot after connecting the mesh interface instead of every interval
- fix #209 