### PR TITLE
Improve debug logging for node and telemetry data

### DIFF
--- a/data/mesh.py
+++ b/data/mesh.py
@@ -333,9 +333,7 @@ def upsert_node(node_id, n):
         user = _get(ndict, "user") or {}
         short = _get(user, "shortName")
         long = _get(user, "longName")
-        _debug_log(
-            f"upserted node {node_id} shortName={short!r} longName={long!r}"
-        )
+        _debug_log(f"upserted node {node_id} shortName={short!r} longName={long!r}")
 
 
 # --- Message logging via PubSub -----------------------------------------------
@@ -901,9 +899,7 @@ def store_position_packet(packet: dict, decoded: Mapping):
     )
 
     if DEBUG:
-        _debug_log(
-            f"stored position for {node_id} lat={latitude!r} lon={longitude!r}"
-        )
+        _debug_log(f"stored position for {node_id} lat={latitude!r} lon={longitude!r}")
 
 
 def store_telemetry_packet(packet: dict, decoded: Mapping):

--- a/data/mesh.py
+++ b/data/mesh.py
@@ -332,7 +332,10 @@ def upsert_node(node_id, n):
     if DEBUG:
         user = _get(ndict, "user") or {}
         short = _get(user, "shortName")
-        _debug_log(f"upserted node {node_id} shortName={short!r}")
+        long = _get(user, "longName")
+        _debug_log(
+            f"upserted node {node_id} shortName={short!r} longName={long!r}"
+        )
 
 
 # --- Message logging via PubSub -----------------------------------------------
@@ -899,7 +902,7 @@ def store_position_packet(packet: dict, decoded: Mapping):
 
     if DEBUG:
         _debug_log(
-            f"stored position for {node_id} lat={latitude!r} lon={longitude!r} rx_time={rx_time}"
+            f"stored position for {node_id} lat={latitude!r} lon={longitude!r}"
         )
 
 
@@ -1053,7 +1056,7 @@ def store_telemetry_packet(packet: dict, decoded: Mapping):
 
     if DEBUG:
         _debug_log(
-            f"stored telemetry for {node_id!r} rx_time={rx_time} battery={battery_level!r}"
+            f"stored telemetry for {node_id!r} battery={battery_level!r} voltage={voltage!r}"
         )
 
 
@@ -1204,7 +1207,12 @@ def store_nodeinfo_packet(packet: dict, decoded: Mapping):
         short = None
         if isinstance(user_dict, Mapping):
             short = user_dict.get("shortName")
-        _debug_log(f"stored nodeinfo for {node_id} shortName={short!r}")
+            long = user_dict.get("longName")
+        else:
+            long = None
+        _debug_log(
+            f"stored nodeinfo for {node_id} shortName={short!r} longName={long!r}"
+        )
 
 
 def store_packet_dict(p: dict):


### PR DESCRIPTION
## Summary
- include both short and long names when logging node upserts and stored nodeinfo
- streamline stored position debug log by removing the rx_time value
- remove rx_time from telemetry debug logging and include the voltage metric instead