### PR TITLE
Add debug logs for unknown node creation and last-heard updates

### DIFF
--- a/web/app.rb
+++ b/web/app.rb
@@ -737,8 +737,8 @@ def ensure_unknown_node(db, node_ref, fallback_num = nil, heard_time: nil)
 
   if inserted
     debug_log(
-      "ensure_unknown_node created hidden node_id=#{node_id} from=#{node_ref.inspect} "
-      "fallback=#{fallback_num.inspect} heard_time=#{heard_time.inspect}",
+      "ensure_unknown_node created hidden node_id=#{node_id} from=#{node_ref.inspect} " \
+      "fallback=#{fallback_num.inspect} heard_time=#{heard_time.inspect}"
     )
   end
 
@@ -788,8 +788,8 @@ def touch_node_last_seen(db, node_ref, fallback_num = nil, rx_time: nil, source:
 
   if updated
     debug_log(
-      "touch_node_last_seen updated last_heard node_id=#{node_id} timestamp=#{timestamp} "
-      "source=#{(source || :unknown).inspect}",
+      "touch_node_last_seen updated last_heard node_id=#{node_id} timestamp=#{timestamp} " \
+      "source=#{(source || :unknown).inspect}"
     )
   end
 


### PR DESCRIPTION
## Summary
- add a debug_log helper wired to the Sinatra logger when DEBUG is enabled
- emit debug output when ensure_unknown_node inserts a hidden placeholder for an unknown sender
- log last_heard updates with context when telemetry, position, or message data refresh node records
