### PR TITLE
Add neighbor info ingestion and API endpoints

### DIFF
--- a/data/neighbors.sql
+++ b/data/neighbors.sql
@@ -29,3 +29,18 @@ CREATE TABLE IF NOT EXISTS neighbors (
 
 CREATE INDEX IF NOT EXISTS idx_neighbors_rx_time ON neighbors(rx_time);
 CREATE INDEX IF NOT EXISTS idx_neighbors_node_id ON neighbors(node_id);
+
+CREATE TABLE IF NOT EXISTS neighbor_peers (
+    neighbor_id   INTEGER NOT NULL,
+    node_id       TEXT,
+    node_num      INTEGER,
+    last_heard    INTEGER,
+    last_heard_iso TEXT,
+    rssi          INTEGER,
+    snr           REAL,
+    PRIMARY KEY (neighbor_id, node_id, node_num),
+    FOREIGN KEY (neighbor_id) REFERENCES neighbors(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_neighbor_peers_neighbor_id ON neighbor_peers(neighbor_id);
+CREATE INDEX IF NOT EXISTS idx_neighbor_peers_node_id ON neighbor_peers(node_id);

--- a/data/neighbors.sql
+++ b/data/neighbors.sql
@@ -1,0 +1,31 @@
+-- Copyright (C) 2025 l5yth
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+CREATE TABLE IF NOT EXISTS neighbors (
+    id                               INTEGER PRIMARY KEY,
+    rx_time                          INTEGER NOT NULL,
+    rx_iso                           TEXT NOT NULL,
+    from_id                          TEXT,
+    to_id                            TEXT,
+    node_id                          TEXT,
+    last_sent_by_id                  TEXT,
+    node_broadcast_interval_secs     INTEGER,
+    hop_limit                        INTEGER,
+    snr                              REAL,
+    rssi                             INTEGER,
+    bitfield                         INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_neighbors_rx_time ON neighbors(rx_time);
+CREATE INDEX IF NOT EXISTS idx_neighbors_node_id ON neighbors(node_id);

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -1101,6 +1101,26 @@ def test_store_packet_dict_handles_neighborinfo_packet(mesh_module, monkeypatch)
                 "nodeId": 2_660_618_080,
                 "lastSentById": 2_660_618_080,
                 "nodeBroadcastIntervalSecs": 3600,
+                "neighbors": [
+                    {
+                        "nodeId": 2_323_365_906,
+                        "rssi": -72,
+                        "snr": 11.8,
+                        "lastHeard": 1_758_621_390,
+                    },
+                    {
+                        "nodeId": 2_477_461_759,
+                        "rssi": -81,
+                        "snr": 7.4,
+                        "lastHeard": 1_758_621_373,
+                    },
+                    {
+                        "nodeId": 2_133_973_413,
+                        "rssi": -96,
+                        "snr": 1.9,
+                        "lastHeard": 1_758_620_715,
+                    },
+                ],
             },
         },
     }
@@ -1121,6 +1141,17 @@ def test_store_packet_dict_handles_neighborinfo_packet(mesh_module, monkeypatch)
     assert payload["snr"] == pytest.approx(3.5)
     assert payload["rssi"] == -80
     assert payload["bitfield"] == 1
+    assert "neighbors" in payload
+    neighbors = payload["neighbors"]
+    assert isinstance(neighbors, list)
+    assert len(neighbors) == 3
+    assert neighbors[0]["node_id"] == "!8a7bc012"
+    assert neighbors[0]["node_num"] == 2_323_365_906
+    assert neighbors[0]["last_heard"] == 1_758_621_390
+    assert neighbors[0]["rssi"] == -72
+    assert neighbors[0]["snr"] == pytest.approx(11.8)
+    assert neighbors[1]["node_id"] == "!93ab10ff"
+    assert neighbors[2]["node_id"] == "!7f31d9a5"
 
 def test_post_queue_prioritises_messages(mesh_module, monkeypatch):
     mesh = mesh_module

--- a/web/app.rb
+++ b/web/app.rb
@@ -1465,13 +1465,23 @@ def insert_neighbor(db, payload)
   raw_from_id = payload["from"] if raw_from_id.nil? || raw_from_id.to_s.strip.empty?
   from_num = coerce_integer(payload["from_num"] || payload["num"])
 
+  canonical_from_id = nil
+  from_parts = canonical_node_parts(raw_from_id, from_num)
+  if from_parts
+    canonical_from_id, canonical_from_num, = from_parts
+    from_num ||= canonical_from_num
+  else
+    canonical_from_id = string_or_nil(normalize_node_id(db, raw_from_id))
+  end
+
   trimmed_from_id = string_or_nil(raw_from_id)
-  canonical_from_id = string_or_nil(normalize_node_id(db, raw_from_id))
   from_id = trimmed_from_id
   if canonical_from_id
     if from_id.nil? || from_id.match?(/\A[0-9]+\z/)
       from_id = canonical_from_id
     elsif from_id.start_with?("!") && from_id.casecmp(canonical_from_id) != 0
+      from_id = canonical_from_id
+    elsif from_parts
       from_id = canonical_from_id
     end
   end


### PR DESCRIPTION
## Summary
- add a dedicated `neighbors` table and expose `/api/neighbors` GET and POST endpoints
- extend the Sinatra API to persist neighbor broadcasts, updating placeholder nodes and last-heard metadata
- update the Meshtastic ingestion daemon and tests to forward and validate NEIGHBORINFO_APP packets
- fix #156 