### PR TITLE
Add neighbor info ingestion and API endpoints

### DIFF
--- a/data/neighbors.sql
+++ b/data/neighbors.sql
@@ -1,0 +1,26 @@
+-- Copyright (C) 2025 l5yth
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+CREATE TABLE IF NOT EXISTS neighbors (
+    node_id     TEXT NOT NULL,
+    neighbor_id TEXT NOT NULL,
+    snr         REAL,
+    rx_time     INTEGER NOT NULL,
+    PRIMARY KEY (node_id, neighbor_id),
+    FOREIGN KEY (node_id) REFERENCES nodes(node_id) ON DELETE CASCADE,
+    FOREIGN KEY (neighbor_id) REFERENCES nodes(node_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_neighbors_rx_time ON neighbors(rx_time);
+CREATE INDEX IF NOT EXISTS idx_neighbors_neighbor_id ON neighbors(neighbor_id);


### PR DESCRIPTION
## Summary
- add a new neighbors table and enable foreign key enforcement in the web app database bootstrap
- expose GET/POST /api/neighbors endpoints that track neighbor tuples and update node metadata
- extend the ingest daemon and test suites to forward and validate NEIGHBORINFO_APP packets

## Testing
- `pytest tests/test_mesh.py`
- `bundle exec rspec` *(fails: bundler cannot download gems in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e228498fe4832b8e2cb90d376c1bd0