### PR TITLE
Adjust mesh priorities and receive topics

### DIFF
--- a/data/mesh.py
+++ b/data/mesh.py
@@ -165,20 +165,23 @@ _POST_QUEUE = []
 _POST_QUEUE_COUNTER = itertools.count()
 _POST_QUEUE_ACTIVE = False
 
-_MESSAGE_POST_PRIORITY = 0
-_POSITION_POST_PRIORITY = 10
-_NEIGHBOR_POST_PRIORITY = 12
-_TELEMETRY_POST_PRIORITY = 15
-_NODE_POST_PRIORITY = 20
-_DEFAULT_POST_PRIORITY = 50
+_MESSAGE_POST_PRIORITY = 10
+_NEIGHBOR_POST_PRIORITY = 20
+_POSITION_POST_PRIORITY = 30
+_TELEMETRY_POST_PRIORITY = 40
+_NODE_POST_PRIORITY = 50
+_DEFAULT_POST_PRIORITY = 90
 
 _RECEIVE_TOPICS = (
     "meshtastic.receive",
     "meshtastic.receive.text",
     "meshtastic.receive.position",
-    "meshtastic.receive.POSITION_APP",
     "meshtastic.receive.user",
+    "meshtastic.receive.POSITION_APP",
     "meshtastic.receive.NODEINFO_APP",
+    "meshtastic.receive.NEIGHBORINFO_APP",
+    "meshtastic.receive.TEXT_MESSAGE_APP",
+    "meshtastic.receive.TELEMETRY_APP",
 )
 
 


### PR DESCRIPTION
## Summary
- update the mesh POST queue priorities to match the new desired ordering
- subscribe to additional Meshtastic receive topics for neighbor, text, and telemetry apps

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e29fe328d0832b8833fc08620fbef5