### PR TITLE
Handle Bluetooth shutdown hangs gracefully

### DIFF
--- a/data/mesh.py
+++ b/data/mesh.py
@@ -98,6 +98,7 @@ def _debug_log(message: str):
 # variables to ease testing while keeping sensible defaults in production.
 _RECONNECT_INITIAL_DELAY_SECS = float(os.environ.get("MESH_RECONNECT_INITIAL", "5"))
 _RECONNECT_MAX_DELAY_SECS = float(os.environ.get("MESH_RECONNECT_MAX", "60"))
+_CLOSE_TIMEOUT_SECS = float(os.environ.get("MESH_CLOSE_TIMEOUT", "5"))
 
 
 class _DummySerialInterface:
@@ -1609,10 +1610,28 @@ def main():
     def _close_interface(iface_obj):
         if iface_obj is None:
             return
-        try:
-            iface_obj.close()
-        except Exception:
-            pass
+
+        def _do_close():
+            try:
+                iface_obj.close()
+            except Exception as exc:
+                if DEBUG:
+                    _debug_log(f"error while closing mesh interface: {exc}")
+
+        if _CLOSE_TIMEOUT_SECS <= 0:
+            _do_close()
+            return
+
+        close_thread = threading.Thread(
+            target=_do_close, name="mesh-close", daemon=True
+        )
+        close_thread.start()
+        close_thread.join(_CLOSE_TIMEOUT_SECS)
+        if close_thread.is_alive():
+            print(
+                "[warn] mesh interface did not close within "
+                f"{_CLOSE_TIMEOUT_SECS:g}s; continuing shutdown"
+            )
 
     iface = None
     resolved_target = None
@@ -1627,10 +1646,13 @@ def main():
         stop.set()
 
     def handle_sigint(signum, frame):
-        """Handle ``SIGINT`` by stopping and propagating ``KeyboardInterrupt``."""
+        """Handle ``SIGINT`` by requesting shutdown and escalating on repeat."""
+
+        if stop.is_set():
+            signal.default_int_handler(signum, frame)
+            return
 
         stop.set()
-        signal.default_int_handler(signum, frame)
 
     signal.signal(signal.SIGINT, handle_sigint)
     signal.signal(signal.SIGTERM, handle_sigterm)


### PR DESCRIPTION
## Summary
- add a configurable timeout to guard mesh interface shutdown
- close interfaces on a background thread to avoid blocking on BLE disconnects
- treat the first SIGINT as a graceful shutdown request and fall back to the default handler on repeat signals

## Testing
- black data/mesh.py

------
https://chatgpt.com/codex/tasks/task_e_68e2bd839578832b9b00dc1ec95f6c6b