### PR TITLE
Reduce neighbor line opacity

### DIFF
--- a/web/views/index.erb
+++ b/web/views/index.erb
@@ -1859,7 +1859,7 @@ var(--fg); }
             L.polyline(segment.latlngs, {
               color: segment.color,
               weight: 2,
-              opacity: 0.6,
+              opacity: 0.42,
               className: 'neighbor-connection-line'
             }).addTo(neighborLinesLayer);
           });


### PR DESCRIPTION
## Summary
- lower the neighbor connection polyline opacity on the map to 42% to make the UI less overwhelming
