### PR TITLE
Add overlay for clickable neighbor links on map

### DIFF
--- a/web/views/index.erb
+++ b/web/views/index.erb
@@ -1420,6 +1420,9 @@ var(--fg); }
         }
         return;
       }
+      if (event.target.closest('.neighbor-connection-line')) {
+        return;
+      }
       if (shortInfoOverlay && !shortInfoOverlay.hidden && !shortInfoOverlay.contains(event.target)) {
         closeShortInfoOverlay();
       }

--- a/web/views/index.erb
+++ b/web/views/index.erb
@@ -72,6 +72,7 @@ var(--line); }
   tbody tr:nth-child(even) td { background: var(--row-alt); }
   .leaflet-container { background: transparent !important; color:
 var(--fg); }
+  .neighbor-connection-line { cursor: pointer; }
 </style>
 <script>
     (function () {
@@ -1621,6 +1622,24 @@ var(--fg); }
       requestAnimationFrame(positionShortInfoOverlay);
     }
 
+    function openNeighborOverlay(target, segment) {
+      if (!shortInfoOverlay || !shortInfoContent || !segment) return;
+      const nodeName = shortInfoValueOrDash(segment.sourceDisplayName || segment.sourceId || '');
+      const neighborName = shortInfoValueOrDash(segment.targetDisplayName || segment.targetId || '');
+      const snrText = shortInfoValueOrDash(formatSnrDisplay(segment.snr));
+      const sourceIdHtml = segment.sourceId ? ` <span class="mono">${escapeHtml(segment.sourceId)}</span>` : '';
+      const targetIdHtml = segment.targetId ? ` <span class="mono">${escapeHtml(segment.targetId)}</span>` : '';
+      const lines = [];
+      lines.push(`<strong>${escapeHtml(nodeName)}</strong>${sourceIdHtml}`);
+      lines.push(`Neighbor: ${escapeHtml(neighborName)}${targetIdHtml}`);
+      lines.push(`SNR: ${escapeHtml(snrText)}`);
+      shortInfoContent.innerHTML = lines.join('<br/>');
+      shortInfoAnchor = target;
+      shortInfoOverlay.hidden = false;
+      shortInfoOverlay.style.visibility = 'hidden';
+      requestAnimationFrame(positionShortInfoOverlay);
+    }
+
     function maybeCreateDateDivider(ts) {
       if (!ts) return null;
       const d = new Date(ts * 1000);
@@ -1752,10 +1771,26 @@ var(--fg); }
       return Number.isFinite(n) ? `${n.toFixed(1)} hPa` : "";
     }
 
+    function formatSnrDisplay(value) {
+      if (value == null || value === '') return '';
+      const n = Number(value);
+      if (!Number.isFinite(n)) return '';
+      return `${n.toFixed(1)} dB`;
+    }
+
     function normalizeNodeNameValue(value) {
       if (value == null) return '';
       const str = String(value).trim();
       return str.length ? str : '';
+    }
+
+    function getNodeDisplayNameForOverlay(node) {
+      if (!node || typeof node !== 'object') return '';
+      return (
+        normalizeNodeNameValue(node.long_name ?? node.longName) ||
+        normalizeNodeNameValue(node.short_name ?? node.shortName) ||
+        (typeof node.node_id === 'string' ? node.node_id : '')
+      );
     }
 
     function applyNodeNameFallback(node) {
@@ -2110,13 +2145,20 @@ var(--fg); }
             rxTime = Number.isFinite(parsed) ? parsed : 0;
           }
 
+          const snrValue = toFiniteNumber(entry.snr);
+          const sourceDisplayName = getNodeDisplayNameForOverlay(sourceNode);
+          const targetDisplayName = getNodeDisplayNameForOverlay(targetNode);
+
           neighborSegments.push({
             latlngs: [[srcLat, srcLon], [tgtLat, tgtLon]],
             color: getRoleColor(sourceNode.role),
             priority,
             rxTime,
             sourceId,
-            targetId
+            targetId,
+            snr: snrValue,
+            sourceDisplayName,
+            targetDisplayName
           });
         }
 
@@ -2129,12 +2171,26 @@ var(--fg); }
             return 0;
           })
           .forEach(segment => {
-            L.polyline(segment.latlngs, {
+            const polyline = L.polyline(segment.latlngs, {
               color: segment.color,
               weight: 2,
               opacity: 0.42,
               className: 'neighbor-connection-line'
             }).addTo(neighborLinesLayer);
+            if (polyline && typeof polyline.on === 'function') {
+              polyline.on('click', event => {
+                const clickTarget = event.originalEvent && typeof Element !== 'undefined' && event.originalEvent.target instanceof Element
+                  ? event.originalEvent.target
+                  : null;
+                const anchorEl = polyline.getElement() || clickTarget;
+                if (!anchorEl) return;
+                if (shortInfoOverlay && !shortInfoOverlay.hidden && shortInfoAnchor === anchorEl) {
+                  closeShortInfoOverlay();
+                  return;
+                }
+                openNeighborOverlay(anchorEl, segment);
+              });
+            }
           });
       }
 

--- a/web/views/index.erb
+++ b/web/views/index.erb
@@ -73,6 +73,7 @@ var(--line); }
   .leaflet-container { background: transparent !important; color:
 var(--fg); }
   .neighbor-connection-line { cursor: pointer; }
+  .neighbor-snr { margin-left: 4px; color: var(--muted); font-size: 12px; }
 </style>
 <script>
     (function () {
@@ -1493,26 +1494,55 @@ var(--fg); }
 
     function getNeighborNodesFor(nodeId) {
       if (typeof nodeId !== 'string' || nodeId.length === 0) return [];
-      const seen = new Set();
-      const neighbors = [];
-      if (!Array.isArray(allNeighbors) || allNeighbors.length === 0) return neighbors;
+      if (!Array.isArray(allNeighbors) || allNeighbors.length === 0) return [];
+      const neighborsById = new Map();
       for (const entry of allNeighbors) {
         if (!entry || typeof entry !== 'object') continue;
         const sourceId = typeof entry.node_id === 'string' ? entry.node_id : null;
         if (sourceId !== nodeId) continue;
         const neighborId = typeof entry.neighbor_id === 'string' ? entry.neighbor_id : null;
-        if (!neighborId || seen.has(neighborId)) continue;
-        seen.add(neighborId);
-        const neighborNode = nodesById.get(neighborId);
-        if (neighborNode) {
-          neighbors.push(neighborNode);
+        if (!neighborId) continue;
+        const snrValue = toFiniteNumber(entry.snr);
+        const rxTime = resolveTimestampSeconds(entry.rx_time, entry.rxTime);
+        let record = neighborsById.get(neighborId);
+        if (!record) {
+          let neighborNode = nodesById.get(neighborId);
+          if (!neighborNode) {
+            const placeholder = { node_id: neighborId };
+            applyNodeNameFallback(placeholder);
+            neighborNode = placeholder;
+          }
+          record = {
+            node: neighborNode,
+            neighborId,
+            snr: snrValue != null ? snrValue : null,
+            rxTime: rxTime != null ? rxTime : null
+          };
+          neighborsById.set(neighborId, record);
           continue;
         }
-        const placeholder = { node_id: neighborId };
-        applyNodeNameFallback(placeholder);
-        neighbors.push(placeholder);
+        if (snrValue != null && (record.snr == null || snrValue > record.snr)) {
+          record.snr = snrValue;
+        }
+        if (rxTime != null && (record.rxTime == null || rxTime > record.rxTime)) {
+          record.rxTime = rxTime;
+        }
       }
-      return neighbors;
+      return Array.from(neighborsById.values());
+    }
+
+    function renderNeighborWithSnrHtml(neighborEntry) {
+      if (!neighborEntry || !neighborEntry.node) return '';
+      const node = neighborEntry.node;
+      const shortHtml = renderShortHtml(
+        node && (node.short_name ?? node.shortName),
+        node && node.role,
+        node && (node.long_name ?? node.longName),
+        node
+      );
+      if (!shortHtml) return '';
+      const snrText = shortInfoValueOrDash(formatSnrDisplay(neighborEntry.snr));
+      return `${shortHtml}<span class="neighbor-snr">(SNR ${escapeHtml(snrText)})</span>`;
     }
 
     function formatShortInfoUptime(value) {
@@ -1586,15 +1616,10 @@ var(--fg); }
         lines.push(`Role: ${escapeHtml(roleValue)}`);
       }
       let neighborLineHtml = '';
-      const neighborNodes = getNeighborNodesFor(info.nodeId);
-      if (neighborNodes.length) {
-        const neighborParts = neighborNodes
-          .map(node => renderShortHtml(
-            node && (node.short_name ?? node.shortName),
-            node && node.role,
-            node && (node.long_name ?? node.longName),
-            node
-          ))
+      const neighborEntries = getNeighborNodesFor(info.nodeId);
+      if (neighborEntries.length) {
+        const neighborParts = neighborEntries
+          .map(renderNeighborWithSnrHtml)
           .filter(html => html && html.length);
         if (neighborParts.length) {
           neighborLineHtml = `Neighbors: ${neighborParts.join(' ')}`;
@@ -2179,9 +2204,20 @@ var(--fg); }
             }).addTo(neighborLinesLayer);
             if (polyline && typeof polyline.on === 'function') {
               polyline.on('click', event => {
-                const clickTarget = event.originalEvent && typeof Element !== 'undefined' && event.originalEvent.target instanceof Element
-                  ? event.originalEvent.target
-                  : null;
+                if (event && event.originalEvent) {
+                  if (typeof event.originalEvent.preventDefault === 'function') {
+                    event.originalEvent.preventDefault();
+                  }
+                  if (typeof event.originalEvent.stopPropagation === 'function') {
+                    event.originalEvent.stopPropagation();
+                  }
+                }
+                const clickTarget =
+                  event.originalEvent &&
+                  typeof Element !== 'undefined' &&
+                  event.originalEvent.target instanceof Element
+                    ? event.originalEvent.target
+                    : null;
                 const anchorEl = polyline.getElement() || clickTarget;
                 if (!anchorEl) return;
                 if (shortInfoOverlay && !shortInfoOverlay.hidden && shortInfoAnchor === anchorEl) {
@@ -2253,15 +2289,10 @@ var(--fg); }
         if (n.uptime_seconds) {
           lines.push(`Uptime: ${timeHum(n.uptime_seconds)}`);
         }
-        const mapNeighborNodes = getNeighborNodesFor(n.node_id ?? n.nodeId ?? '');
-        if (mapNeighborNodes.length) {
-          const neighborParts = mapNeighborNodes
-            .map(node => renderShortHtml(
-              node && (node.short_name ?? node.shortName),
-              node && node.role,
-              node && (node.long_name ?? node.longName),
-              node
-            ))
+        const mapNeighborEntries = getNeighborNodesFor(n.node_id ?? n.nodeId ?? '');
+        if (mapNeighborEntries.length) {
+          const neighborParts = mapNeighborEntries
+            .map(renderNeighborWithSnrHtml)
             .filter(html => html && html.length);
           if (neighborParts.length) {
             lines.push(`Neighbors: ${neighborParts.join(' ')}`);


### PR DESCRIPTION
## Summary
- make neighbor connection polylines interactive on the map
- reuse the short info overlay to show node, neighbor, and SNR details when a line is clicked
- add helper utilities for formatting SNR values and deriving display names for neighbor overlays