### PR TITLE
Hide Air Util Tx column on mobile

### DIFF
--- a/web/views/index.erb
+++ b/web/views/index.erb
@@ -385,6 +385,8 @@ var(--fg); }
       #nodes td:nth-child(6),
       #nodes th:nth-child(9),
       #nodes td:nth-child(9),
+      #nodes th:nth-child(11),
+      #nodes td:nth-child(11),
       #nodes th:nth-child(13),
       #nodes td:nth-child(13),
       #nodes th:nth-child(14),


### PR DESCRIPTION
## Summary
- hide the Air Util Tx column from the node table when viewed on mobile-sized screens to reduce clutter

## Testing
- black .

------
https://chatgpt.com/codex/tasks/task_e_68e35a2d8344832bbf59ee89cedf789c