### PR TITLE
Add legend toggle for neighbor lines

### DIFF
--- a/web/views/index.erb
+++ b/web/views/index.erb
@@ -838,6 +838,8 @@ var(--fg); }
     let usingOfflineTiles = false;
     const MAX_NODE_DISTANCE_KM = <%= max_node_distance_km %>;
     let neighborLinesLayer = null;
+    let neighborLinesVisible = true;
+    let neighborLinesToggleButton = null;
     let markersLayer = null;
     let tileDomObserver = null;
 
@@ -1214,6 +1216,27 @@ var(--fg); }
       updateLegendToggleState();
     }
 
+    function updateNeighborLinesToggleState() {
+      if (!neighborLinesToggleButton) return;
+      const label = neighborLinesVisible ? 'Hide neighbor lines' : 'Show neighbor lines';
+      neighborLinesToggleButton.textContent = label;
+      neighborLinesToggleButton.setAttribute('aria-pressed', neighborLinesVisible ? 'true' : 'false');
+      neighborLinesToggleButton.setAttribute('aria-label', label);
+    }
+
+    function setNeighborLinesVisibility(visible) {
+      neighborLinesVisible = Boolean(visible);
+      if (neighborLinesLayer && map) {
+        const hasLayer = map.hasLayer(neighborLinesLayer);
+        if (neighborLinesVisible && !hasLayer) {
+          neighborLinesLayer.addTo(map);
+        } else if (!neighborLinesVisible && hasLayer) {
+          map.removeLayer(neighborLinesLayer);
+        }
+      }
+      updateNeighborLinesToggleState();
+    }
+
     function updateLegendRoleFiltersUI() {
       const hasFilters = activeRoleFilters.size > 0;
       legendRoleButtons.forEach((button, role) => {
@@ -1256,12 +1279,12 @@ var(--fg); }
         title.textContent = 'Legend';
 
         const itemsContainer = L.DomUtil.create('div', 'legend-items', div);
-        legendRoleButtons.clear();
-        for (const [role, color] of Object.entries(roleColors)) {
-          if (!CHAT_ENABLED && role === 'CLIENT_HIDDEN') continue;
-          const item = L.DomUtil.create('button', 'legend-item', itemsContainer);
-          item.type = 'button';
-          item.setAttribute('aria-pressed', 'false');
+      legendRoleButtons.clear();
+      for (const [role, color] of Object.entries(roleColors)) {
+        if (!CHAT_ENABLED && role === 'CLIENT_HIDDEN') continue;
+        const item = L.DomUtil.create('button', 'legend-item', itemsContainer);
+        item.type = 'button';
+        item.setAttribute('aria-pressed', 'false');
           item.dataset.role = role;
           const swatch = L.DomUtil.create('span', 'legend-swatch', item);
           swatch.style.background = color;
@@ -1286,6 +1309,15 @@ var(--fg); }
         updateLegendRoleFiltersUI();
 
         const toggle = L.DomUtil.create('div', 'legend-toggle', div);
+        neighborLinesToggleButton = L.DomUtil.create('button', 'legend-item legend-toggle-neighbors', toggle);
+        neighborLinesToggleButton.type = 'button';
+        neighborLinesToggleButton.addEventListener('click', event => {
+          event.preventDefault();
+          event.stopPropagation();
+          setNeighborLinesVisibility(!neighborLinesVisible);
+        });
+        updateNeighborLinesToggleState();
+
         const resetButton = L.DomUtil.create('button', 'legend-item legend-reset', toggle);
         resetButton.type = 'button';
         resetButton.textContent = 'Clear filters';


### PR DESCRIPTION
## Summary
- add a legend control button to hide or show neighbor connection lines
- track neighbor line visibility state and update map layer membership accordingly

## Testing
- black .
- bundle exec rufo *(fails: bundler could not install dependencies due to 403 errors from rubygems.org)*

------
https://chatgpt.com/codex/tasks/task_e_68e35a9aa380832b95d37cacc90a125e