### PR TITLE
Force dark theme default based on sanitized cookie

### DIFF
--- a/web/app.rb
+++ b/web/app.rb
@@ -1956,7 +1956,11 @@ get "/" do
   meta = meta_configuration
   config = frontend_app_config
 
-  response.set_cookie("theme", value: "dark", path: "/", max_age: 60 * 60 * 24 * 7, same_site: :lax) unless request.cookies["theme"]
+  raw_theme = request.cookies["theme"]
+  theme = %w[dark light].include?(raw_theme) ? raw_theme : "dark"
+  if raw_theme != theme
+    response.set_cookie("theme", value: theme, path: "/", max_age: 60 * 60 * 24 * 7, same_site: :lax)
+  end
 
   erb :index, locals: {
                 site_name: meta[:name],
@@ -1973,5 +1977,6 @@ get "/" do
                 private_mode: private_mode?,
                 refresh_interval_seconds: REFRESH_INTERVAL_SECONDS,
                 app_config_json: JSON.generate(config),
+                initial_theme: theme,
               }
 end

--- a/web/public/assets/js/app/main.js
+++ b/web/public/assets/js/app/main.js
@@ -938,6 +938,10 @@ export function initializeApp(config) {
     themeToggle.addEventListener('click', () => {
       const dark = document.body.classList.toggle('dark');
       const themeValue = dark ? 'dark' : 'light';
+      document.body.setAttribute('data-theme', themeValue);
+      if (document.documentElement) {
+        document.documentElement.setAttribute('data-theme', themeValue);
+      }
       themeToggle.textContent = dark ? '☀️' : '🌙';
       if (window.__themeCookie) {
         if (typeof window.__themeCookie.persistTheme === 'function') {

--- a/web/public/assets/js/theme.js
+++ b/web/public/assets/js/theme.js
@@ -26,28 +26,49 @@
     setCookie('theme', value, { 'max-age': THEME_COOKIE_MAX_AGE });
   }
 
+  function applyTheme(value) {
+    var themeValue = value === 'dark' ? 'dark' : 'light';
+    var root = document.documentElement;
+    var isDark = themeValue === 'dark';
+
+    if (root) {
+      root.setAttribute('data-theme', themeValue);
+    }
+
+    if (document.body) {
+      document.body.classList.toggle('dark', isDark);
+      document.body.setAttribute('data-theme', themeValue);
+    }
+
+    return isDark;
+  }
+
   var theme = getCookie('theme');
   if (theme !== 'dark' && theme !== 'light') {
     theme = 'dark';
   }
   persistTheme(theme);
 
-  document.addEventListener('DOMContentLoaded', function () {
-    if (theme === 'dark') {
-      document.body.classList.add('dark');
-    } else {
-      document.body.classList.remove('dark');
-    }
+  applyTheme(theme);
+
+  function handleReady() {
+    var isDark = applyTheme(theme);
 
     var btn = document.getElementById('themeToggle');
     if (btn) {
-      btn.textContent = document.body.classList.contains('dark') ? '☀️' : '🌙';
+      btn.textContent = isDark ? '☀️' : '🌙';
     }
 
     if (typeof window.applyFiltersToAllTiles === 'function') {
       window.applyFiltersToAllTiles();
     }
-  });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', handleReady);
+  } else {
+    handleReady();
+  }
 
   window.__themeCookie = {
     getCookie: getCookie,

--- a/web/public/assets/styles/base.css
+++ b/web/public/assets/styles/base.css
@@ -9,9 +9,22 @@
   --row-alt: rgba(0, 0, 0, 0.02);
   --table-head-bg: rgba(0, 0, 0, 0.06);
   --table-head-fg: var(--fg);
+  --input-bg: #ffffff;
+  --input-fg: var(--fg);
+  --input-border: rgba(12, 15, 18, 0.18);
+  --input-placeholder: rgba(12, 15, 18, 0.45);
+  --control-accent: var(--accent);
   --pad: 16px;
   --map-tile-filter-light: grayscale(1) saturate(0) brightness(0.92) contrast(1.05);
   --map-tile-filter-dark: grayscale(1) invert(1) brightness(0.9) contrast(1.08);
+}
+
+html {
+  color-scheme: light;
+}
+
+html[data-theme='dark'] {
+  color-scheme: dark;
 }
 
 body.dark {
@@ -25,6 +38,11 @@ body.dark {
   --row-alt: rgba(255, 255, 255, 0.05);
   --table-head-bg: rgba(255, 255, 255, 0.06);
   --table-head-fg: var(--fg);
+  --input-bg: #1e262c;
+  --input-fg: var(--fg);
+  --input-border: rgba(230, 235, 240, 0.24);
+  --input-placeholder: rgba(230, 235, 240, 0.55);
+  --control-accent: var(--accent);
 }
 
 html,
@@ -457,8 +475,28 @@ label {
 
 input[type="text"] {
   padding: 6px 10px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--input-border);
   border-radius: 6px;
+  background: var(--input-bg);
+  color: var(--input-fg);
+  transition: background-color 160ms ease, color 160ms ease, border-color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+input[type="text"]::placeholder {
+  color: var(--input-placeholder);
+}
+
+input[type="text"]:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-color: var(--accent);
+}
+
+input[type="checkbox"],
+input[type="radio"] {
+  accent-color: var(--control-accent);
+  transition: accent-color 160ms ease, background-color 160ms ease;
 }
 
 .legend {
@@ -816,12 +854,6 @@ body.dark .sort-button:hover {
 
 body.dark label {
   color: #ddd;
-}
-
-body.dark input[type="text"] {
-  background: #222;
-  color: #eee;
-  border-color: #444;
 }
 
 body.dark .legend {

--- a/web/views/index.erb
+++ b/web/views/index.erb
@@ -16,7 +16,7 @@
   limitations under the License.
 -->
 
-<html lang="en">
+<html lang="en" data-theme="<%= initial_theme %>">
 <head>
   <meta name="color-scheme" content="dark light">
   <meta charset="utf-8" />
@@ -73,7 +73,9 @@
   
   
 </head>
-<body data-app-config="<%= Rack::Utils.escape_html(app_config_json) %>">
+  <% body_classes = [] %>
+  <% body_classes << "dark" if initial_theme == "dark" %>
+<body class="<%= body_classes.join(" ") %>" data-app-config="<%= Rack::Utils.escape_html(app_config_json) %>" data-theme="<%= initial_theme %>">
   <h1 class="site-title">
     <img src="/potatomesh-logo.svg" alt="" aria-hidden="true" />
     <span class="site-title-text"><%= site_name %></span>


### PR DESCRIPTION
## Summary
- sanitize the theme cookie and pass the initial theme into the layout so the first paint respects the stored preference
- update the theme initialization logic to apply HTML/body attributes immediately and keep them in sync when toggled
- fix #250 