### PR TITLE
Add JSDoc documentation across client scripts

### DIFF
--- a/web/public/assets/js/app/config.js
+++ b/web/public/assets/js/app/config.js
@@ -1,5 +1,15 @@
+/**
+ * CSS selector used to locate the embedded configuration element.
+ *
+ * @type {string}
+ */
 const CONFIG_SELECTOR = '[data-app-config]';
 
+/**
+ * Read and parse the serialized application configuration from the DOM.
+ *
+ * @returns {Object<string, *>} Parsed configuration object or an empty object when unavailable.
+ */
 export function readAppConfig() {
   const el = document.querySelector(CONFIG_SELECTOR);
   if (!el) {

--- a/web/public/assets/js/app/index.js
+++ b/web/public/assets/js/app/index.js
@@ -1,6 +1,20 @@
 import { readAppConfig } from './config.js';
 import { initializeApp } from './main.js';
 
+/**
+ * Default configuration values applied when the server omits a field.
+ *
+ * @type {{
+ *   refreshMs: number,
+ *   refreshIntervalSeconds: number,
+ *   chatEnabled: boolean,
+ *   defaultChannel: string,
+ *   defaultFrequency: string,
+ *   mapCenter: { lat: number, lon: number },
+ *   maxNodeDistanceKm: number,
+ *   tileFilters: { light: string, dark: string }
+ * }}
+ */
 const DEFAULT_CONFIG = {
   refreshMs: 60_000,
   refreshIntervalSeconds: 60,
@@ -15,6 +29,12 @@ const DEFAULT_CONFIG = {
   }
 };
 
+/**
+ * Merge raw configuration data from the DOM with the defaults.
+ *
+ * @param {Object<string, *>} raw Partial configuration read from ``readAppConfig``.
+ * @returns {typeof DEFAULT_CONFIG} Fully populated configuration object.
+ */
 function mergeConfig(raw) {
   const config = { ...DEFAULT_CONFIG, ...(raw || {}) };
   config.mapCenter = {
@@ -43,6 +63,12 @@ function mergeConfig(raw) {
   return config;
 }
 
+/**
+ * Bootstraps the application once the DOM is ready by reading configuration
+ * data and delegating to ``initializeApp``.
+ *
+ * @returns {void}
+ */
 document.addEventListener('DOMContentLoaded', () => {
   const rawConfig = readAppConfig();
   const config = mergeConfig(rawConfig);

--- a/web/public/assets/js/app/main.js
+++ b/web/public/assets/js/app/main.js
@@ -1,3 +1,19 @@
+/**
+ * Entry point for the interactive dashboard. Wires up event listeners,
+ * initializes the map, and triggers the first data refresh cycle.
+ *
+ * @param {{
+ *   refreshMs: number,
+ *   refreshIntervalSeconds: number,
+ *   chatEnabled: boolean,
+ *   defaultChannel: string,
+ *   defaultFrequency: string,
+ *   mapCenter: { lat: number, lon: number },
+ *   maxNodeDistanceKm: number,
+ *   tileFilters: { light: string, dark: string }
+ * }} config Normalized application configuration.
+ * @returns {void}
+ */
 export function initializeApp(config) {
   const statusEl = document.getElementById('status');
   const fitBoundsEl = document.getElementById('fitBounds');
@@ -519,6 +535,12 @@ export function initializeApp(config) {
   function createOfflineTileLayer() {
     if (!hasLeaflet) return null;
     const offlineLayer = L.gridLayer({ className: 'map-tiles map-tiles-offline' });
+    /**
+     * Render a placeholder tile for offline map usage.
+     *
+     * @param {{x: number, y: number, z: number}} coords Tile coordinates supplied by Leaflet.
+     * @returns {HTMLCanvasElement} Canvas element containing placeholder artwork.
+     */
     offlineLayer.createTile = coords => {
       const size = 256;
       const canvas = document.createElement('canvas');
@@ -706,6 +728,11 @@ export function initializeApp(config) {
   }
 
   if (typeof window !== 'undefined') {
+    /**
+     * Helper exposed for the theme module to refresh Leaflet tile filters.
+     *
+     * @type {function(): void}
+     */
     window.applyFiltersToAllTiles = applyFiltersToAllTiles;
   }
 
@@ -1074,7 +1101,7 @@ export function initializeApp(config) {
    * @param {?Object} nodeData Optional node metadata attached to the badge.
    * @returns {string} HTML snippet describing the badge.
    */
-  function renderShortHtml(short, role, longName, nodeData = null){
+  function renderShortHtml(short, role, longName, nodeData = null) {
     const safeTitle = longName ? escapeHtml(String(longName)) : '';
     const titleAttr = safeTitle ? ` title="${safeTitle}"` : '';
     const roleValue = normalizeRole(role != null && role !== '' ? role : (nodeData && nodeData.role));

--- a/web/public/assets/js/background.js
+++ b/web/public/assets/js/background.js
@@ -1,6 +1,11 @@
 (function () {
   'use strict';
 
+  /**
+   * Resolve the background colour that should be applied to the document.
+   *
+   * @returns {?string} CSS colour string or ``null`` if resolution fails.
+   */
   function resolveBackgroundColor() {
     if (!document.body) {
       return null;
@@ -26,6 +31,11 @@
     return color;
   }
 
+  /**
+   * Apply the resolved background colour to the page root elements.
+   *
+   * @returns {void}
+   */
   function applyBackground() {
     var color = resolveBackgroundColor();
     if (!color) {
@@ -38,6 +48,11 @@
     document.body.style.backgroundImage = 'none';
   }
 
+  /**
+   * Initialize the background helper once the DOM is ready.
+   *
+   * @returns {void}
+   */
   function init() {
     applyBackground();
   }
@@ -50,6 +65,14 @@
 
   window.addEventListener('themechange', applyBackground);
 
+  /**
+   * Testing hooks exposing background helpers.
+   *
+   * @type {{
+   *   applyBackground: function(): void,
+   *   resolveBackgroundColor: function(): (?string)
+   * }}
+   */
   window.__potatoBackground = {
     applyBackground: applyBackground,
     resolveBackgroundColor: resolveBackgroundColor

--- a/web/public/assets/js/theme.js
+++ b/web/public/assets/js/theme.js
@@ -1,6 +1,17 @@
 (function () {
+  /**
+   * Number of seconds theme preferences should persist in the cookie store.
+   *
+   * @type {number}
+   */
   var THEME_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 
+  /**
+   * Retrieve a cookie value by name.
+   *
+   * @param {string} name Cookie identifier.
+   * @returns {?string} Decoded cookie value or ``null`` when absent.
+   */
   function getCookie(name) {
     var matcher = new RegExp(
       '(?:^|; )' + name.replace(/([.$?*|{}()\[\]\\/+^])/g, '\\$1') + '=([^;]*)'
@@ -9,6 +20,14 @@
     return match ? decodeURIComponent(match[1]) : null;
   }
 
+  /**
+   * Persist a cookie with optional attributes.
+   *
+   * @param {string} name Cookie identifier.
+   * @param {string} value Value to store.
+   * @param {Object<string, *>} [opts] Additional cookie attributes.
+   * @returns {void}
+   */
   function setCookie(name, value, opts) {
     var options = Object.assign(
       { path: '/', 'max-age': THEME_COOKIE_MAX_AGE, SameSite: 'Lax' },
@@ -22,6 +41,12 @@
     document.cookie = updated;
   }
 
+  /**
+   * Store the user's preferred theme selection.
+   *
+   * @param {string} value Theme identifier to persist.
+   * @returns {void}
+   */
   function persistTheme(value) {
     setCookie('theme', value, { 'max-age': THEME_COOKIE_MAX_AGE });
   }
@@ -32,6 +57,11 @@
   }
   persistTheme(theme);
 
+  /**
+   * Apply the stored theme and refresh dependent UI elements once the DOM is ready.
+   *
+   * @returns {void}
+   */
   document.addEventListener('DOMContentLoaded', function () {
     if (theme === 'dark') {
       document.body.classList.add('dark');
@@ -49,6 +79,16 @@
     }
   });
 
+  /**
+   * Testing hooks exposing cookie helpers for integration tests.
+   *
+   * @type {{
+   *   getCookie: function(string): (?string),
+   *   setCookie: function(string, string, Object<string, *>=): void,
+   *   persistTheme: function(string): void,
+   *   maxAge: number
+   * }}
+   */
   window.__themeCookie = {
     getCookie: getCookie,
     setCookie: setCookie,


### PR DESCRIPTION
## Summary
- document configuration bootstrap logic with detailed JSDoc blocks
- expand inline documentation throughout the main app entrypoint and utility scripts
- expose theme and background helpers with typed annotations for testing hooks
