### PR TITLE
Document mesh ingestor modules with PDoc-style docstrings

### DIFF
--- a/data/mesh_ingestor/__init__.py
+++ b/data/mesh_ingestor/__init__.py
@@ -60,6 +60,8 @@ class _MeshIngestorModule(types.ModuleType):
     """Module proxy that forwards config and interface state."""
 
     def __getattr__(self, name: str):  # type: ignore[override]
+        """Resolve attributes by delegating to the underlying submodules."""
+
         if name in _CONFIG_ATTRS:
             return getattr(config, name)
         if name in _INTERFACE_ATTRS:
@@ -69,6 +71,8 @@ class _MeshIngestorModule(types.ModuleType):
         raise AttributeError(name)
 
     def __setattr__(self, name: str, value):  # type: ignore[override]
+        """Propagate assignments to the appropriate submodule."""
+
         if name in _CONFIG_ATTRS:
             setattr(config, name, value)
             super().__setattr__(name, value)

--- a/data/mesh_ingestor/config.py
+++ b/data/mesh_ingestor/config.py
@@ -18,7 +18,11 @@ _CLOSE_TIMEOUT_SECS = float(os.environ.get("MESH_CLOSE_TIMEOUT", "5"))
 
 
 def _debug_log(message: str) -> None:
-    """Print ``message`` with a UTC timestamp when ``DEBUG`` is enabled."""
+    """Print ``message`` with a UTC timestamp when ``DEBUG`` is enabled.
+
+    Parameters:
+        message: Text to display when debug logging is active.
+    """
 
     if not DEBUG:
         return

--- a/data/mesh_ingestor/daemon.py
+++ b/data/mesh_ingestor/daemon.py
@@ -25,6 +25,12 @@ _RECEIVE_TOPICS = (
 
 
 def _event_wait_allows_default_timeout() -> bool:
+    """Return ``True`` when :meth:`threading.Event.wait` accepts ``timeout``.
+
+    The behaviour changed between Python versions; this helper shields the
+    daemon from ``TypeError`` when the default timeout parameter is absent.
+    """
+
     try:
         wait_signature = inspect.signature(threading.Event.wait)
     except (TypeError, ValueError):  # pragma: no cover
@@ -45,6 +51,8 @@ def _event_wait_allows_default_timeout() -> bool:
 
 
 def _subscribe_receive_topics() -> list[str]:
+    """Subscribe the packet handler to all receive-related pubsub topics."""
+
     subscribed = []
     for topic in _RECEIVE_TOPICS:
         try:
@@ -58,6 +66,18 @@ def _subscribe_receive_topics() -> list[str]:
 def _node_items_snapshot(
     nodes_obj, retries: int = 3
 ) -> list[tuple[str, object]] | None:
+    """Snapshot ``nodes_obj`` to avoid iteration errors during updates.
+
+    Parameters:
+        nodes_obj: Meshtastic nodes mapping or iterable.
+        retries: Number of attempts when encountering "dictionary changed"
+            runtime errors.
+
+    Returns:
+        A list of ``(node_id, node)`` tuples, ``None`` when retries are
+        exhausted, or an empty list when no nodes exist.
+    """
+
     if not nodes_obj:
         return []
 
@@ -87,6 +107,8 @@ def _node_items_snapshot(
 
 
 def _close_interface(iface_obj) -> None:
+    """Close ``iface_obj`` while respecting configured timeouts."""
+
     if iface_obj is None:
         return
 
@@ -112,6 +134,8 @@ def _close_interface(iface_obj) -> None:
 
 
 def main() -> None:
+    """Run the mesh ingestion daemon until interrupted."""
+
     subscribed = _subscribe_receive_topics()
     if config.DEBUG and subscribed:
         config._debug_log(f"subscribed to receive topics: {', '.join(subscribed)}")

--- a/data/mesh_ingestor/interfaces.py
+++ b/data/mesh_ingestor/interfaces.py
@@ -1,9 +1,8 @@
-"""Mesh interface discovery helpers."""
+"""Mesh interface discovery helpers for interacting with Meshtastic hardware."""
 
 from __future__ import annotations
 
 import glob
-import inspect
 import ipaddress
 import re
 import urllib.parse
@@ -45,7 +44,14 @@ class _DummySerialInterface:
 
 
 def _parse_ble_target(value: str) -> str | None:
-    """Return an uppercase BLE MAC address when ``value`` matches the format."""
+    """Return an uppercase BLE MAC address when ``value`` matches the format.
+
+    Parameters:
+        value: User-provided target string.
+
+    Returns:
+        The normalised MAC address or ``None`` when validation fails.
+    """
 
     if not value:
         return None
@@ -58,7 +64,14 @@ def _parse_ble_target(value: str) -> str | None:
 
 
 def _parse_network_target(value: str) -> tuple[str, int] | None:
-    """Return ``(host, port)`` when ``value`` is an IP address string."""
+    """Return ``(host, port)`` when ``value`` is an IP address string.
+
+    Parameters:
+        value: Hostname or URL describing the TCP interface.
+
+    Returns:
+        A ``(host, port)`` tuple or ``None`` when parsing fails.
+    """
 
     if not value:
         return None
@@ -104,7 +117,14 @@ def _parse_network_target(value: str) -> tuple[str, int] | None:
 
 
 def _load_ble_interface():
-    """Return :class:`meshtastic.ble_interface.BLEInterface` when available."""
+    """Return :class:`meshtastic.ble_interface.BLEInterface` when available.
+
+    Returns:
+        The resolved BLE interface class.
+
+    Raises:
+        RuntimeError: If the BLE dependencies are not installed.
+    """
 
     global BLEInterface
     if BLEInterface is not None:
@@ -131,7 +151,14 @@ def _load_ble_interface():
 
 
 def _create_serial_interface(port: str) -> tuple[object, str]:
-    """Return an appropriate mesh interface for ``port``."""
+    """Return an appropriate mesh interface for ``port``.
+
+    Parameters:
+        port: User-supplied port string which may represent serial, BLE or TCP.
+
+    Returns:
+        ``(interface, resolved_target)`` describing the created interface.
+    """
 
     port_value = (port or "").strip()
     if port_value.lower() in {"", "mock", "none", "null", "disabled"}:
@@ -158,7 +185,7 @@ class NoAvailableMeshInterface(RuntimeError):
 
 
 def _default_serial_targets() -> list[str]:
-    """Return a list of candidate serial device paths for auto-discovery."""
+    """Return candidate serial device paths for auto-discovery."""
 
     candidates: list[str] = []
     seen: set[str] = set()
@@ -173,7 +200,14 @@ def _default_serial_targets() -> list[str]:
 
 
 def _create_default_interface() -> tuple[object, str]:
-    """Attempt to create the default mesh interface, raising on failure."""
+    """Attempt to create the default mesh interface, raising on failure.
+
+    Returns:
+        ``(interface, resolved_target)`` for the discovered connection.
+
+    Raises:
+        NoAvailableMeshInterface: When no usable connection can be created.
+    """
 
     errors: list[tuple[str, Exception]] = []
     for candidate in _default_serial_targets():

--- a/data/mesh_ingestor/queue.py
+++ b/data/mesh_ingestor/queue.py
@@ -40,7 +40,14 @@ def _post_json(
     instance: str | None = None,
     api_token: str | None = None,
 ) -> None:
-    """Send a JSON payload to the configured web API."""
+    """Send a JSON payload to the configured web API.
+
+    Parameters:
+        path: API path relative to the configured instance root.
+        payload: JSON-serialisable body to transmit.
+        instance: Optional override for :data:`config.INSTANCE`.
+        api_token: Optional override for :data:`config.API_TOKEN`.
+    """
 
     if instance is None:
         instance = config.INSTANCE
@@ -70,7 +77,14 @@ def _enqueue_post_json(
     *,
     state: QueueState = STATE,
 ) -> None:
-    """Store a POST request in the priority queue."""
+    """Store a POST request in the priority queue.
+
+    Parameters:
+        path: API path for the queued request.
+        payload: JSON-serialisable body.
+        priority: Lower values execute first.
+        state: Shared queue state, injectable for testing.
+    """
 
     with state.lock:
         counter = next(state.counter)
@@ -80,7 +94,12 @@ def _enqueue_post_json(
 def _drain_post_queue(
     state: QueueState = STATE, send: Callable[[str, dict], None] | None = None
 ) -> None:
-    """Process queued POST requests in priority order."""
+    """Process queued POST requests in priority order.
+
+    Parameters:
+        state: Queue container holding pending items.
+        send: Optional callable used to transmit requests.
+    """
 
     if send is None:
         send = _post_json
@@ -105,7 +124,15 @@ def _queue_post_json(
     state: QueueState = STATE,
     send: Callable[[str, dict], None] | None = None,
 ) -> None:
-    """Queue a POST request and start processing if idle."""
+    """Queue a POST request and start processing if idle.
+
+    Parameters:
+        path: API path for the request.
+        payload: JSON payload to send.
+        priority: Scheduling priority where lower values run first.
+        state: Queue container used to store pending requests.
+        send: Optional transport override, primarily for tests.
+    """
 
     if send is None:
         send = _post_json
@@ -119,7 +146,11 @@ def _queue_post_json(
 
 
 def _clear_post_queue(state: QueueState = STATE) -> None:
-    """Clear the pending POST queue (used by tests)."""
+    """Clear the pending POST queue.
+
+    Parameters:
+        state: Queue state to reset. Defaults to the global queue.
+    """
 
     with state.lock:
         state.queue.clear()

--- a/tests/debug.py
+++ b/tests/debug.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Interactive debugging helpers for live Meshtastic sessions."""
+
 import time, json, base64, threading
 from pubsub import pub  # comes with meshtastic
 from meshtastic.serial_interface import SerialInterface
@@ -28,7 +30,14 @@ stop = threading.Event()
 
 
 def to_jsonable(obj):
-    """Recursively convert protobuf/bytes/etc. into JSON-serializable structures."""
+    """Recursively convert complex objects into JSON-serialisable structures.
+
+    Parameters:
+        obj: Any Meshtastic-related payload or protobuf message.
+
+    Returns:
+        A structure composed of standard Python types.
+    """
     if obj is None:
         return None
     if isinstance(obj, ProtoMessage):
@@ -49,7 +58,14 @@ def to_jsonable(obj):
 
 
 def extract_text(d):
-    """Best-effort pull of decoded text from a dict produced by to_jsonable()."""
+    """Best-effort pull of decoded text from :func:`to_jsonable` output.
+
+    Parameters:
+        d: Mapping derived from :func:`to_jsonable`.
+
+    Returns:
+        The decoded text when available, otherwise ``None``.
+    """
     dec = d.get("decoded") or {}
     # Text packets usually at decoded.payload.text
     payload = dec.get("payload") or {}
@@ -62,6 +78,12 @@ def extract_text(d):
 
 
 def on_receive(packet, interface):
+    """Display human-readable output for each received packet.
+
+    Parameters:
+        packet: Packet instance supplied by Meshtastic.
+        interface: Interface that produced the packet.
+    """
     global packet_count, last_rx_ts
     packet_count += 1
     last_rx_ts = time.time()
@@ -86,14 +108,20 @@ def on_receive(packet, interface):
 
 
 def on_connected(interface, *args, **kwargs):
+    """Log when a connection is established."""
+
     print("[info] connection established")
 
 
 def on_disconnected(interface, *args, **kwargs):
+    """Log when the interface disconnects."""
+
     print("[info] disconnected")
 
 
 def main():
+    """Run the interactive debugging loop."""
+
     print(f"Opening Meshtastic on {PORT} …")
 
     # Use PubSub topics (reliable in current meshtastic)

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -2,6 +2,9 @@ import base64
 import importlib
 import sys
 import types
+
+"""End-to-end tests covering the mesh ingestion package."""
+
 from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
@@ -11,7 +14,7 @@ import pytest
 
 @pytest.fixture
 def mesh_module(monkeypatch):
-    """Import data.mesh with stubbed dependencies."""
+    """Import :mod:`data.mesh` with stubbed dependencies."""
 
     repo_root = Path(__file__).resolve().parents[1]
     monkeypatch.syspath_prepend(str(repo_root))


### PR DESCRIPTION
## Summary
- document the mesh ingestor modules with PDoc-style descriptions for exported helpers and proxy behaviors
- add inline documentation to supporting scripts and tests to improve generated API docs
