### PR TITLE
Add energy saving cycle to ingestor daemon

### DIFF
--- a/data/mesh_ingestor/config.py
+++ b/data/mesh_ingestor/config.py
@@ -11,10 +11,15 @@ CHANNEL_INDEX = int(os.environ.get("MESH_CHANNEL_INDEX", "0"))
 DEBUG = os.environ.get("DEBUG") == "1"
 INSTANCE = os.environ.get("POTATOMESH_INSTANCE", "").rstrip("/")
 API_TOKEN = os.environ.get("API_TOKEN", "")
+ENERGY_SAVING = os.environ.get("ENERGY_SAVING") == "1"
 
 _RECONNECT_INITIAL_DELAY_SECS = float(os.environ.get("MESH_RECONNECT_INITIAL", "5"))
 _RECONNECT_MAX_DELAY_SECS = float(os.environ.get("MESH_RECONNECT_MAX", "60"))
 _CLOSE_TIMEOUT_SECS = float(os.environ.get("MESH_CLOSE_TIMEOUT", "5"))
+_ENERGY_ONLINE_DURATION_SECS = float(
+    os.environ.get("ENERGY_ONLINE_DURATION_SECS", "300")
+)
+_ENERGY_SLEEP_SECS = float(os.environ.get("ENERGY_SLEEP_SECS", str(6 * 60 * 60)))
 
 
 def _debug_log(message: str) -> None:
@@ -38,8 +43,11 @@ __all__ = [
     "DEBUG",
     "INSTANCE",
     "API_TOKEN",
+    "ENERGY_SAVING",
     "_RECONNECT_INITIAL_DELAY_SECS",
     "_RECONNECT_MAX_DELAY_SECS",
     "_CLOSE_TIMEOUT_SECS",
+    "_ENERGY_ONLINE_DURATION_SECS",
+    "_ENERGY_SLEEP_SECS",
     "_debug_log",
 ]

--- a/data/mesh_ingestor/daemon.py
+++ b/data/mesh_ingestor/daemon.py
@@ -133,6 +133,18 @@ def _close_interface(iface_obj) -> None:
         )
 
 
+def _is_ble_interface(iface_obj) -> bool:
+    """Return ``True`` when ``iface_obj`` appears to be a BLE interface."""
+
+    if iface_obj is None:
+        return False
+    iface_cls = getattr(iface_obj, "__class__", None)
+    if iface_cls is None:
+        return False
+    module_name = getattr(iface_cls, "__module__", "") or ""
+    return "ble_interface" in module_name
+
+
 def main() -> None:
     """Run the mesh ingestion daemon until interrupted."""
 
@@ -146,6 +158,20 @@ def main() -> None:
 
     stop = threading.Event()
     initial_snapshot_sent = False
+    energy_session_deadline = None
+
+    energy_saving_enabled = config.ENERGY_SAVING
+    energy_online_secs = max(0.0, config._ENERGY_ONLINE_DURATION_SECS)
+    energy_sleep_secs = max(0.0, config._ENERGY_SLEEP_SECS)
+
+    def _energy_sleep(reason: str) -> None:
+        if not energy_saving_enabled or energy_sleep_secs <= 0:
+            return
+        if config.DEBUG:
+            config._debug_log(
+                f"energy saving: {reason}; sleeping for {energy_sleep_secs:g}s"
+            )
+        stop.wait(energy_sleep_secs)
 
     def handle_sigterm(*_args) -> None:
         stop.set()
@@ -182,6 +208,10 @@ def main() -> None:
                     if not announced_target and resolved_target:
                         print(f"[info] using mesh interface: {resolved_target}")
                         announced_target = True
+                    if energy_saving_enabled and energy_online_secs > 0:
+                        energy_session_deadline = time.monotonic() + energy_online_secs
+                    else:
+                        energy_session_deadline = None
                 except interfaces.NoAvailableMeshInterface as exc:
                     print(f"[error] {exc}")
                     _close_interface(iface)
@@ -204,6 +234,34 @@ def main() -> None:
                             ),
                             config._RECONNECT_MAX_DELAY_SECS,
                         )
+                    continue
+
+            if energy_saving_enabled and iface is not None:
+                if (
+                    energy_session_deadline is not None
+                    and time.monotonic() >= energy_session_deadline
+                ):
+                    print("[info] energy saving: disconnecting mesh interface")
+                    _close_interface(iface)
+                    iface = None
+                    announced_target = False
+                    initial_snapshot_sent = False
+                    energy_session_deadline = None
+                    _energy_sleep("disconnected after session")
+                    continue
+                if (
+                    _is_ble_interface(iface)
+                    and getattr(iface, "client", object()) is None
+                ):
+                    print(
+                        "[info] energy saving: BLE client disconnected; sleeping before retry"
+                    )
+                    _close_interface(iface)
+                    iface = None
+                    announced_target = False
+                    initial_snapshot_sent = False
+                    energy_session_deadline = None
+                    _energy_sleep("BLE client disconnected")
                     continue
 
             if not initial_snapshot_sent:
@@ -258,5 +316,6 @@ __all__ = [
     "_event_wait_allows_default_timeout",
     "_node_items_snapshot",
     "_subscribe_receive_topics",
+    "_is_ble_interface",
     "main",
 ]


### PR DESCRIPTION
## Summary
- add ENERGY_SAVING configuration and tunable timing values for the ingestor
- update the ingestor daemon to cycle connections and sleep when energy saving is enabled
- detect silent BLE disconnects in energy saving mode and back off before reconnecting

## Testing
- black data/mesh_ingestor/config.py data/mesh_ingestor/daemon.py
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e4ba9b783c832b8d552650040419b4