### PR TITLE
Add fullscreen toggle to map view

### DIFF
--- a/web/public/assets/js/app/main.js
+++ b/web/public/assets/js/app/main.js
@@ -326,7 +326,7 @@ export function initializeApp(config) {
     const label = active ? 'Exit full screen map view' : 'Enter full screen map view';
     mapFullscreenToggle.setAttribute('aria-pressed', active ? 'true' : 'false');
     mapFullscreenToggle.setAttribute('aria-label', label);
-    mapFullscreenToggle.textContent = '[]';
+    mapFullscreenToggle.dataset.fullscreen = active ? 'true' : 'false';
   }
 
   /**
@@ -427,6 +427,23 @@ export function initializeApp(config) {
     }
     if (fullscreenContainer !== mapContainer && mapContainer && mapContainer.classList) {
       mapContainer.classList.toggle('is-fullscreen', active);
+    }
+    if (mapContainer && mapContainer.style) {
+      if (active) {
+        mapContainer.style.width = '100vw';
+        mapContainer.style.height = '100vh';
+        mapContainer.style.maxWidth = '100vw';
+        mapContainer.style.maxHeight = '100vh';
+        mapContainer.style.minWidth = '100vw';
+        mapContainer.style.minHeight = '100vh';
+      } else {
+        mapContainer.style.width = '';
+        mapContainer.style.height = '';
+        mapContainer.style.maxWidth = '';
+        mapContainer.style.maxHeight = '';
+        mapContainer.style.minWidth = '';
+        mapContainer.style.minHeight = '';
+      }
     }
     updateFullscreenToggleState();
     refreshMapSize();

--- a/web/public/assets/js/app/main.js
+++ b/web/public/assets/js/app/main.js
@@ -324,10 +324,9 @@ export function initializeApp(config) {
     if (!mapFullscreenToggle) return;
     const active = isMapInFullscreen();
     const label = active ? 'Exit full screen map view' : 'Enter full screen map view';
-    const text = active ? 'Exit full screen' : 'Full screen';
     mapFullscreenToggle.setAttribute('aria-pressed', active ? 'true' : 'false');
     mapFullscreenToggle.setAttribute('aria-label', label);
-    mapFullscreenToggle.textContent = text;
+    mapFullscreenToggle.textContent = '[]';
   }
 
   /**
@@ -422,6 +421,13 @@ export function initializeApp(config) {
    * @returns {void}
    */
   function handleFullscreenChange() {
+    const active = isMapInFullscreen();
+    if (fullscreenContainer && fullscreenContainer.classList) {
+      fullscreenContainer.classList.toggle('is-fullscreen', active);
+    }
+    if (fullscreenContainer !== mapContainer && mapContainer && mapContainer.classList) {
+      mapContainer.classList.toggle('is-fullscreen', active);
+    }
     updateFullscreenToggleState();
     refreshMapSize();
   }

--- a/web/public/assets/styles/base.css
+++ b/web/public/assets/styles/base.css
@@ -156,6 +156,44 @@ h1 {
   justify-content: center;
 }
 
+.map-panel:fullscreen,
+.map-panel:-webkit-full-screen,
+.map-panel:-moz-full-screen,
+.map-panel:-ms-fullscreen,
+#map:fullscreen,
+#map:-webkit-full-screen,
+#map:-moz-full-screen,
+#map:-ms-fullscreen {
+  width: 100vw;
+  height: 100vh;
+  margin: 0;
+  border: none;
+  border-radius: 0;
+  background: #000;
+}
+
+.map-panel:fullscreen #map,
+.map-panel:-webkit-full-screen #map,
+.map-panel:-moz-full-screen #map,
+.map-panel:-ms-fullscreen #map,
+#map:fullscreen,
+#map:-webkit-full-screen,
+#map:-moz-full-screen,
+#map:-ms-fullscreen {
+  height: 100vh;
+  width: 100vw;
+  border: none;
+  border-radius: 0;
+}
+
+.map-panel:fullscreen .map-toolbar,
+.map-panel:-webkit-full-screen .map-toolbar,
+.map-panel:-moz-full-screen .map-toolbar,
+.map-panel:-ms-fullscreen .map-toolbar {
+  top: 16px;
+  right: 16px;
+}
+
 #map[data-map-status="placeholder"] {
   background: repeating-linear-gradient(
     135deg,
@@ -224,6 +262,16 @@ body.dark #map .map-status-message {
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
 }
 
+body.dark .map-toolbar button {
+  background: rgba(36, 36, 36, 0.88);
+  color: #f1f1f1;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+}
+
+body.dark .map-toolbar button:hover {
+  background: rgba(52, 52, 52, 0.9);
+}
+
 table {
   border-collapse: collapse;
   width: 100%;
@@ -257,6 +305,40 @@ th {
   display: flex;
   gap: var(--pad);
   align-items: stretch;
+}
+
+.map-panel {
+  position: relative;
+  flex: 1;
+  display: flex;
+  min-width: 0;
+}
+
+.map-toolbar {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  display: flex;
+  gap: 8px;
+  z-index: 1300;
+  pointer-events: none;
+}
+
+.map-toolbar button {
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  font-size: 13px;
+  line-height: 1.2;
+  transition: background-color 160ms ease, color 160ms ease, border-color 160ms ease,
+    box-shadow 160ms ease;
+  pointer-events: auto;
+}
+
+.map-toolbar button:hover {
+  background: rgba(245, 245, 245, 0.95);
 }
 
 #chat {

--- a/web/public/assets/styles/base.css
+++ b/web/public/assets/styles/base.css
@@ -168,10 +168,22 @@ h1 {
 #map:-ms-fullscreen {
   width: 100vw;
   height: 100vh;
+  min-width: 100vw;
+  min-height: 100vh;
+  max-width: 100vw;
+  max-height: 100vh;
   margin: 0;
   border: none;
   border-radius: 0;
   background: #000;
+}
+
+.map-panel.is-fullscreen,
+.map-panel:fullscreen,
+.map-panel:-webkit-full-screen,
+.map-panel:-moz-full-screen,
+.map-panel:-ms-fullscreen {
+  display: block;
 }
 
 .map-panel.is-fullscreen #map,
@@ -184,10 +196,15 @@ h1 {
 #map:-webkit-full-screen,
 #map:-moz-full-screen,
 #map:-ms-fullscreen {
-  height: 100vh;
-  width: 100vw;
+  height: 100vh !important;
+  width: 100vw !important;
+  min-height: 100vh;
+  min-width: 100vw;
+  max-height: 100vh;
+  max-width: 100vw;
   border: none;
   border-radius: 0;
+  flex: none;
 }
 
 .map-panel.is-fullscreen .map-toolbar,
@@ -330,6 +347,9 @@ th {
 }
 
 .map-toolbar button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   padding: 6px 12px;
   border-radius: 999px;
   border: 1px solid rgba(0, 0, 0, 0.2);
@@ -344,6 +364,25 @@ th {
 
 .map-toolbar button:hover {
   background: rgba(245, 245, 245, 0.95);
+}
+
+.map-toolbar button svg {
+  width: 18px;
+  height: 18px;
+  display: block;
+  fill: currentColor;
+}
+
+#mapFullscreenToggle .icon-fullscreen-exit {
+  display: none;
+}
+
+#mapFullscreenToggle[aria-pressed='true'] .icon-fullscreen-exit {
+  display: block;
+}
+
+#mapFullscreenToggle[aria-pressed='true'] .icon-fullscreen-enter {
+  display: none;
 }
 
 #chat {

--- a/web/public/assets/styles/base.css
+++ b/web/public/assets/styles/base.css
@@ -156,10 +156,12 @@ h1 {
   justify-content: center;
 }
 
+.map-panel.is-fullscreen,
 .map-panel:fullscreen,
 .map-panel:-webkit-full-screen,
 .map-panel:-moz-full-screen,
 .map-panel:-ms-fullscreen,
+#map.is-fullscreen,
 #map:fullscreen,
 #map:-webkit-full-screen,
 #map:-moz-full-screen,
@@ -172,10 +174,12 @@ h1 {
   background: #000;
 }
 
+.map-panel.is-fullscreen #map,
 .map-panel:fullscreen #map,
 .map-panel:-webkit-full-screen #map,
 .map-panel:-moz-full-screen #map,
 .map-panel:-ms-fullscreen #map,
+#map.is-fullscreen,
 #map:fullscreen,
 #map:-webkit-full-screen,
 #map:-moz-full-screen,
@@ -186,6 +190,7 @@ h1 {
   border-radius: 0;
 }
 
+.map-panel.is-fullscreen .map-toolbar,
 .map-panel:fullscreen .map-toolbar,
 .map-panel:-webkit-full-screen .map-toolbar,
 .map-panel:-moz-full-screen .map-toolbar,

--- a/web/views/index.erb
+++ b/web/views/index.erb
@@ -133,7 +133,28 @@
     <div class="map-panel" id="mapPanel">
       <div id="map" role="region" aria-label="Nodes map"></div>
       <div class="map-toolbar" role="group" aria-label="Map view controls">
-        <button id="mapFullscreenToggle" type="button" aria-pressed="false" aria-label="Enter full screen map view">[]</button>
+        <button id="mapFullscreenToggle" type="button" aria-pressed="false" aria-label="Enter full screen map view">
+          <svg class="icon-fullscreen-enter" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path
+              d="M4 8V4h4m12 4V4h-4M4 16v4h4m12-4v4h-4"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.8"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+          <svg class="icon-fullscreen-exit" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path
+              d="M9 9L5 5m0 4V5m4 0H5m10 4 4-4m0 4V5m-4 0h4M9 15l-4 4m0-4v4m4 0H5m10-4 4 4m0-4v4m-4 0h4"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.8"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </button>
       </div>
     </div>
   </div>

--- a/web/views/index.erb
+++ b/web/views/index.erb
@@ -133,7 +133,7 @@
     <div class="map-panel" id="mapPanel">
       <div id="map" role="region" aria-label="Nodes map"></div>
       <div class="map-toolbar" role="group" aria-label="Map view controls">
-        <button id="mapFullscreenToggle" type="button" aria-pressed="false" aria-label="Enter full screen map view">Full screen</button>
+        <button id="mapFullscreenToggle" type="button" aria-pressed="false" aria-label="Enter full screen map view">[]</button>
       </div>
     </div>
   </div>

--- a/web/views/index.erb
+++ b/web/views/index.erb
@@ -130,7 +130,12 @@
     <% unless private_mode %>
       <div id="chat" aria-label="Chat log"></div>
     <% end %>
-    <div id="map" role="region" aria-label="Nodes map"></div>
+    <div class="map-panel" id="mapPanel">
+      <div id="map" role="region" aria-label="Nodes map"></div>
+      <div class="map-toolbar" role="group" aria-label="Map view controls">
+        <button id="mapFullscreenToggle" type="button" aria-pressed="false" aria-label="Enter full screen map view">Full screen</button>
+      </div>
+    </div>
   </div>
 
   <table id="nodes">


### PR DESCRIPTION
## Summary
- overlay the map with a fullscreen toggle button and dedicated container
- extend map styling so fullscreen mode fills the viewport without borders and keeps controls accessible
- integrate the Fullscreen API in the map script to request/exit fullscreen and resize Leaflet accordingly
