### PR TITLE
Handle serial disconnects with hourly reconnect attempts

### DIFF
--- a/data/mesh_ingestor/interfaces.py
+++ b/data/mesh_ingestor/interfaces.py
@@ -184,7 +184,9 @@ class _StreamDisconnectHandler(logging.Handler):
         self, record: logging.LogRecord
     ) -> None:  # pragma: no cover - logging glue
         message = record.getMessage()
-        if "Meshtastic serial port disconnected" not in message:
+        if "Meshtastic serial port disconnected" not in message and (
+            "device reports readiness to read but returned no data" not in message
+        ):
             return
         now = time.monotonic()
         with _STREAM_DISCONNECT_LOCK:


### PR DESCRIPTION
## Summary
- record the monotonic timestamp of the last received mesh packet for activity tracking
- capture Meshtastic serial disconnect warnings to note when the radio drops
- update the daemon to pause reconnect attempts for an hour after disconnects or prolonged inactivity
