### PR TITLE
Dockerfile fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,8 @@ WORKDIR /app
 COPY --from=builder /usr/local/bundle /usr/local/bundle
 
 # Copy application code (exclude Dockerfile from web directory)
-COPY --chown=potatomesh:potatomesh web/app.rb web/app.sh web/Gemfile web/Gemfile.lock* web/public/ web/spec/ ./
+COPY --chown=potatomesh:potatomesh web/app.rb web/app.sh web/Gemfile web/Gemfile.lock* web/spec/ ./
+COPY --chown=potatomesh:potatomesh web/public ./public
 COPY --chown=potatomesh:potatomesh web/views/ ./views/
 
 # Copy SQL schema files from data directory


### PR DESCRIPTION
I can't seem to get the `Dockerfile` build in the `web/` directory to work.

When building from that directory, the `Dockerfile` refers to `web/xyz` assets, but that's already the directory we're in (so it'd be looking for `web/web/xyz`).

It shows errors like `ERROR: failed to solve: failed to compute cache key: failed to calculate checksum of ref ...: "/web/views": not found`

```
$ sudo docker build --tag potato-mesh-web .
[+] Building 0.2s (15/17)                                                                                                                                                                                                                                                          docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                         0.0s
 => => transferring dockerfile: 2.18kB                                                                                                                                                                                                                                                       0.0s
 => [internal] load metadata for docker.io/library/ruby:3.3-alpine                                                                                                                                                                                                                           0.1s 
 => [internal] load .dockerignore                                                                                                                                                                                                                                                            0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                                              0.0s
 => [builder 1/5] FROM docker.io/library/ruby:3.3-alpine@sha256:7713cab0b7d5e905cc83ce0874d829da042785030dcf77439319d33e9bef4d46                                                                                                                                                             0.0s 
 => [internal] load build context                                                                                                                                                                                                                                                            0.1s 
 => => transferring context: 2B                                                                                                                                                                                                                                                              0.1s 
 => CACHED [builder 2/5] RUN apk add --no-cache     build-base     sqlite-dev     linux-headers     pkgconfig                                                                                                                                                                                0.0s 
 => CACHED [builder 3/5] WORKDIR /app                                                                                                                                                                                                                                                        0.0s 
 => ERROR [builder 4/5] COPY web/Gemfile web/Gemfile.lock* ./                                                                                                                                                                                                                                0.0s 
 => CACHED [production 2/9] RUN apk add --no-cache     sqlite     tzdata     curl                                                                                                                                                                                                            0.0s 
 => CACHED [production 3/9] RUN addgroup -g 1000 -S potatomesh &&     adduser -u 1000 -S potatomesh -G potatomesh                                                                                                                                                                            0.0s 
 => CACHED [production 4/9] WORKDIR /app                                                                                                                                                                                                                                                     0.0s 
 => CACHED [builder 5/5] RUN bundle config set --local force_ruby_platform true &&     bundle config set --local without 'development test' &&     bundle install --jobs=4 --retry=3                                                                                                         0.0s 
 => CACHED [production 5/9] COPY --from=builder /usr/local/bundle /usr/local/bundle                                                                                                                                                                                                          0.0s 
 => ERROR [production 6/9] COPY --chown=potatomesh:potatomesh web/app.rb web/app.sh web/Gemfile web/Gemfile.lock* web/public/ web/spec/ ./                                                                                                                                                   0.0s 
 => ERROR [production 7/9] COPY --chown=potatomesh:potatomesh web/views/ ./views/                                                                                                                                                                                                            0.0s 
------
 > [builder 4/5] COPY web/Gemfile web/Gemfile.lock* ./:
------
------
 > [production 6/9] COPY --chown=potatomesh:potatomesh web/app.rb web/app.sh web/Gemfile web/Gemfile.lock* web/public/ web/spec/ ./:
------
------
 > [production 7/9] COPY --chown=potatomesh:potatomesh web/views/ ./views/:
------
Dockerfile:47
--------------------
  45 |     # Copy application code (exclude Dockerfile from web directory)
  46 |     COPY --chown=potatomesh:potatomesh web/app.rb web/app.sh web/Gemfile web/Gemfile.lock* web/public/ web/spec/ ./
  47 | >>> COPY --chown=potatomesh:potatomesh web/views/ ./views/
  48 |
  49 |     # Copy SQL schema files from data directory
--------------------
ERROR: failed to solve: failed to compute cache key: failed to calculate checksum of ref d65072aa-5bd7-4c7a-9774-9560ad4c1b68::uya45c33y7gwlmc0opwlde39v: "/web/views": not found
```

Moving the `Dockerfile` to the root source directory and building from there fixes this:

```
$ sudo docker build --tag potato-mesh-web . && sudo docker run --rm -p 0.0.0.0:8080:41447 -e API_TOKEN=test -e PROM_REPORT_IDS=* --name potato-mesh-web potato-mesh-web
[+] Building 0.6s (19/19) FINISHED                                                                                                                                                                                                                                                 docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                         0.0s
 => => transferring dockerfile: 2.23kB                                                                                                                                                                                                                                                       0.0s 
 => [internal] load metadata for docker.io/library/ruby:3.3-alpine                                                                                                                                                                                                                           0.2s 
 => [internal] load .dockerignore                                                                                                                                                                                                                                                            0.0s
 => => transferring context: 815B                                                                                                                                                                                                                                                            0.0s 
 => [internal] load build context                                                                                                                                                                                                                                                            0.3s 
 => => transferring context: 1.18kB                                                                                                                                                                                                                                                          0.3s 
 => [builder 1/5] FROM docker.io/library/ruby:3.3-alpine@sha256:7713cab0b7d5e905cc83ce0874d829da042785030dcf77439319d33e9bef4d46                                                                                                                                                             0.0s 
 => CACHED [production  2/10] RUN apk add --no-cache     sqlite     tzdata     curl                                                                                                                                                                                                          0.0s
 => CACHED [production  3/10] RUN addgroup -g 1000 -S potatomesh &&     adduser -u 1000 -S potatomesh -G potatomesh                                                                                                                                                                          0.0s 
 => CACHED [production  4/10] WORKDIR /app                                                                                                                                                                                                                                                   0.0s 
 => CACHED [builder 2/5] RUN apk add --no-cache     build-base     sqlite-dev     linux-headers     pkgconfig                                                                                                                                                                                0.0s 
 => CACHED [builder 3/5] WORKDIR /app                                                                                                                                                                                                                                                        0.0s 
 => CACHED [builder 4/5] COPY web/Gemfile web/Gemfile.lock* ./                                                                                                                                                                                                                               0.0s 
 => CACHED [builder 5/5] RUN bundle config set --local force_ruby_platform true &&     bundle config set --local without 'development test' &&     bundle install --jobs=4 --retry=3                                                                                                         0.0s 
 => CACHED [production  5/10] COPY --from=builder /usr/local/bundle /usr/local/bundle                                                                                                                                                                                                        0.0s 
 => CACHED [production  6/10] COPY --chown=potatomesh:potatomesh web/app.rb web/app.sh web/Gemfile web/Gemfile.lock* web/spec/ ./                                                                                                                                                            0.0s 
 => CACHED [production  7/10] COPY --chown=potatomesh:potatomesh web/public ./public                                                                                                                                                                                                         0.0s 
 => CACHED [production  8/10] COPY --chown=potatomesh:potatomesh web/views/ ./views/                                                                                                                                                                                                         0.0s 
 => CACHED [production  9/10] COPY --chown=potatomesh:potatomesh data/*.sql /data/                                                                                                                                                                                                           0.0s 
 => CACHED [production 10/10] RUN mkdir -p /app/data &&     chown -R potatomesh:potatomesh /app/data                                                                                                                                                                                         0.0s 
 => exporting to image                                                                                                                                                                                                                                                                       0.0s 
 => => exporting layers                                                                                                                                                                                                                                                                      0.0s 
 => => writing image sha256:1333ec35fe96538f466e8fbdbb6572a130e01ac5bdb73d4fe5b59b472d03444d                                                                                                                                                                                                 0.0s 
 => => naming to docker.io/library/potato-mesh-web                          
```

However, after that, there's still issue where all static `/assets` don't load.

<img width="1164" height="654" alt="image" src="https://github.com/user-attachments/assets/6b0422c0-d40d-421b-813d-8b147fd00108" />

We need to change the `COPY ... web/public/ ./` line to `COPY web/pubic ./public` for those assets to work.

Otherwise the `web/public/*` assets land in `/app/`, while the ruby app is expecting them in `/app/public/`

<img width="1145" height="771" alt="image" src="https://github.com/user-attachments/assets/0499e57d-f89c-4183-855f-7870ce747377" />

I'm not sure if the docker images should be built in a different way, but I couldn't find a way to do it with the layout of the files as-is today.