### PR TITLE
Prometheus metrics updates on startup and for position/telemetry

### DIFF
--- a/web/app.rb
+++ b/web/app.rb
@@ -1649,7 +1649,7 @@ end
 # @param met [Hash] device metrics from the node payload.
 # @param pos [Hash] position information from the node payload.
 # @return [void]
-def update_prometheus_metrics(node_id, user = {}, role = "", met = {}, pos = {})
+def update_prometheus_metrics(node_id, user = nil, role = "", met = nil, pos = nil)
   return if $prom_report_ids.empty? || !node_id
 
   return unless $prom_report_ids[0] == "*" || $prom_report_ids.include?(node_id)
@@ -1661,7 +1661,7 @@ def update_prometheus_metrics(node_id, user = {}, role = "", met = {}, pos = {})
         node: node_id,
         short_name: user["shortName"],
         long_name: user["longName"],
-        hw_model: user["hwModel"] || n["hwModel"],
+        hw_model: user["hwModel"],
         role: role,
       },
     )


### PR DESCRIPTION
Follow-up to https://github.com/l5yth/potato-mesh/pull/262

* Updates Prometheus metrics for all nodes on startup (based on `mesh.db`); otherwise metrics won't be seen until that node is re-inserted later
* Updates Prometheus metrics for telemetry and position updates
* Minor refactoring (to a function that handles the updates) and performance improvements (to not parse `PROM_REPORT_IDS`) for each node