### PR TITLE
Add persistent federation metadata endpoint

### DIFF
--- a/web/app.rb
+++ b/web/app.rb
@@ -53,6 +53,7 @@ def open_database(readonly: false)
     db.execute("PRAGMA foreign_keys = ON")
   end
 end
+
 # Convenience constant used when filtering stale records.
 WEEK_SECONDS = 7 * 24 * 60 * 60
 # Default request body size allowed for JSON uploads.


### PR DESCRIPTION
## Summary
- generate and persist an RSA private key for the instance and log its public key for federation
- expose a signed `.well-known/potato-mesh` document with instance metadata refreshed daily
- log well-known payload updates and signatures for easier debugging
