### PR TITLE
Configure web container for production mode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 x-web-base: &web-base
   image: ghcr.io/l5yth/potato-mesh-web-${POTATOMESH_IMAGE_ARCH:-linux-amd64}:latest
   environment:
+    APP_ENV: ${APP_ENV:-production}
+    RACK_ENV: ${RACK_ENV:-production}
     SITE_NAME: ${SITE_NAME:-My Meshtastic Network}
     DEFAULT_CHANNEL: ${DEFAULT_CHANNEL:-#MediumFast}
     DEFAULT_FREQUENCY: ${DEFAULT_FREQUENCY:-868MHz}
@@ -10,6 +12,7 @@ x-web-base: &web-base
     MATRIX_ROOM: ${MATRIX_ROOM:-}
     API_TOKEN: ${API_TOKEN}
     DEBUG: ${DEBUG:-0}
+  command: ["ruby", "app.rb", "-p", "41447", "-o", "0.0.0.0"]
   volumes:
     - potatomesh_data:/app/data
     - potatomesh_logs:/app/logs

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -63,7 +63,8 @@ USER potatomesh
 EXPOSE 41447
 
 # Default environment variables (can be overridden by host)
-ENV APP_ENV=production \
+ENV RACK_ENV=production \
+    APP_ENV=production \
     MESH_DB=/app/data/mesh.db \
     DB_BUSY_TIMEOUT_MS=5000 \
     DB_BUSY_MAX_RETRIES=5 \


### PR DESCRIPTION
## Summary
- ensure the shared web service configuration defaults to production Rack and app environments
- explicitly run the web container with `ruby app.rb -p 41447 -o 0.0.0.0` to bind on all interfaces
- add the missing `RACK_ENV` default to the web Dockerfile alongside the existing production defaults
