### PR TITLE
Ensure mesh ingestor queue resets active flag when idle

### DIFF
--- a/data/mesh_ingestor/queue.py
+++ b/data/mesh_ingestor/queue.py
@@ -122,6 +122,7 @@ def _drain_post_queue(
         while True:
             with state.lock:
                 if not state.queue:
+                    state.active = False
                     return
                 _priority, _idx, path, payload = heapq.heappop(state.queue)
             send(path, payload)


### PR DESCRIPTION
## Summary
- clear the mesh ingestor queue's active flag while holding the lock when the queue empties

## Testing
- pytest tests/test_mesh.py::test_post_queue_prioritises_messages
- rufo .
- black .

------
https://chatgpt.com/codex/tasks/task_e_68eaa1d43aa8832b80d8fc041e416bd9