### PR TITLE
Clarify numeric address requirement for network target parsing

### DIFF
--- a/data/mesh_ingestor/interfaces.py
+++ b/data/mesh_ingestor/interfaces.py
@@ -215,10 +215,14 @@ def _parse_ble_target(value: str) -> str | None:
 
 
 def _parse_network_target(value: str) -> tuple[str, int] | None:
-    """Return ``(host, port)`` when ``value`` is an IP address string.
+    """Return ``(host, port)`` when ``value`` is a numeric IP address string.
+
+    Only literal IPv4 or IPv6 addresses are accepted, optionally paired with a
+    port or scheme. Callers that start from hostnames should resolve them to an
+    address before invoking this helper.
 
     Parameters:
-        value: Hostname or URL describing the TCP interface.
+        value: Numeric IP literal or URL describing the TCP interface.
 
     Returns:
         A ``(host, port)`` tuple or ``None`` when parsing fails.


### PR DESCRIPTION
## Summary
- clarify that `_parse_network_target` only accepts literal IPv4 or IPv6 addresses
- document how callers should handle hostnames before invoking the helper

## Testing
- rufo .
- black .

------
https://chatgpt.com/codex/tasks/task_e_68eaa1e4cd58832ba1ec5313835f3434