### PR TITLE
Ensure Docker config directories are created for non-root user

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -52,9 +52,10 @@ COPY --chown=potatomesh:potatomesh web/views/ ./views/
 # Copy SQL schema files from data directory
 COPY --chown=potatomesh:potatomesh data/*.sql /data/
 
-# Create data directory for SQLite database
-RUN mkdir -p /app/data && \
-    chown -R potatomesh:potatomesh /app/data
+# Create data and configuration directories with correct ownership
+RUN mkdir -p /app/data \
+    && mkdir -p /app/.config/well-known \
+    && chown -R potatomesh:potatomesh /app/data /app/.config
 
 # Switch to non-root user
 USER potatomesh


### PR DESCRIPTION
## Summary
- create the /app/.config and /app/.config/well-known directories during the image build
- ensure the potatomesh user owns the configuration and data directories before switching users

## Testing
- ⚠️ `docker build web -t potatomesh-web:test` *(fails in CI environment: docker command not available)*

------
https://chatgpt.com/codex/tasks/task_e_68eaa1c55c2c832b9c77637592e8d7b0