### PR TITLE
Refactor config and metadata helpers into PotatoMesh modules

### DIFF
--- a/web/lib/potato_mesh/config.rb
+++ b/web/lib/potato_mesh/config.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+module PotatoMesh
+  module Config
+    module_function
+
+    def web_root
+      @web_root ||= File.expand_path("../..", __dir__)
+    end
+
+    def repo_root
+      @repo_root ||= File.expand_path("..", web_root)
+    end
+
+    def default_db_path
+      File.expand_path("../data/mesh.db", web_root)
+    end
+
+    def db_path
+      ENV.fetch("MESH_DB", default_db_path)
+    end
+
+    def db_busy_timeout_ms
+      ENV.fetch("DB_BUSY_TIMEOUT_MS", "5000").to_i
+    end
+
+    def db_busy_max_retries
+      ENV.fetch("DB_BUSY_MAX_RETRIES", "5").to_i
+    end
+
+    def db_busy_retry_delay
+      ENV.fetch("DB_BUSY_RETRY_DELAY", "0.05").to_f
+    end
+
+    def week_seconds
+      7 * 24 * 60 * 60
+    end
+
+    def default_max_json_body_bytes
+      1_048_576
+    end
+
+    def max_json_body_bytes
+      raw = ENV.fetch("MAX_JSON_BODY_BYTES", default_max_json_body_bytes.to_s)
+      value = Integer(raw, 10)
+      value.positive? ? value : default_max_json_body_bytes
+    rescue ArgumentError
+      default_max_json_body_bytes
+    end
+
+    def version_fallback
+      "v0.5.0"
+    end
+
+    def default_refresh_interval_seconds
+      60
+    end
+
+    def refresh_interval_seconds
+      raw = ENV.fetch("REFRESH_INTERVAL_SECONDS", default_refresh_interval_seconds.to_s)
+      value = Integer(raw, 10)
+      value.positive? ? value : default_refresh_interval_seconds
+    rescue ArgumentError
+      default_refresh_interval_seconds
+    end
+
+    def map_tile_filter_light
+      ENV.fetch(
+        "MAP_TILE_FILTER_LIGHT",
+        "grayscale(1) saturate(0) brightness(0.92) contrast(1.05)",
+      )
+    end
+
+    def map_tile_filter_dark
+      ENV.fetch(
+        "MAP_TILE_FILTER_DARK",
+        "grayscale(1) invert(1) brightness(0.9) contrast(1.08)",
+      )
+    end
+
+    def tile_filters
+      {
+        light: map_tile_filter_light,
+        dark: map_tile_filter_dark,
+      }.freeze
+    end
+
+    def prom_report_ids
+      ENV.fetch("PROM_REPORT_IDS", "")
+    end
+
+    def prom_report_id_list
+      prom_report_ids.split(",").map(&:strip).reject(&:empty?)
+    end
+
+    def keyfile_path
+      File.join(web_root, ".config", "keyfile")
+    end
+
+    def well_known_relative_path
+      File.join(".well-known", "potato-mesh")
+    end
+
+    def well_known_storage_root
+      File.join(web_root, ".config", "well-known")
+    end
+
+    def legacy_public_well_known_path
+      File.join(web_root, "public", well_known_relative_path)
+    end
+
+    def well_known_refresh_interval
+      24 * 60 * 60
+    end
+
+    def instance_signature_algorithm
+      "rsa-sha256"
+    end
+
+    def remote_instance_http_timeout
+      5
+    end
+
+    def remote_instance_max_node_age
+      86_400
+    end
+
+    def remote_instance_min_node_count
+      10
+    end
+
+    def federation_seed_domains
+      ["potatomesh.net"].freeze
+    end
+
+    def federation_announcement_interval
+      24 * 60 * 60
+    end
+
+    def site_name
+      fetch_string("SITE_NAME", "PotatoMesh Demo")
+    end
+
+    def default_channel
+      fetch_string("DEFAULT_CHANNEL", "#LongFast")
+    end
+
+    def default_frequency
+      fetch_string("DEFAULT_FREQUENCY", "915MHz")
+    end
+
+    def map_center_lat
+      ENV.fetch("MAP_CENTER_LAT", "38.761944").to_f
+    end
+
+    def map_center_lon
+      ENV.fetch("MAP_CENTER_LON", "-27.090833").to_f
+    end
+
+    def max_node_distance_km
+      ENV.fetch("MAX_NODE_DISTANCE_KM", "42").to_f
+    end
+
+    def matrix_room
+      ENV.fetch("MATRIX_ROOM", "#potatomesh:dod.ngo")
+    end
+
+    def debug?
+      ENV["DEBUG"] == "1"
+    end
+
+    def fetch_string(key, default)
+      value = ENV[key]
+      return default if value.nil?
+
+      trimmed = value.strip
+      trimmed.empty? ? default : trimmed
+    end
+  end
+end

--- a/web/lib/potato_mesh/meta.rb
+++ b/web/lib/potato_mesh/meta.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require_relative "config"
+require_relative "sanitizer"
+
+module PotatoMesh
+  module Meta
+    module_function
+
+    def formatted_distance_km(distance)
+      format("%.1f", distance).sub(/\.0\z/, "")
+    end
+
+    def description(private_mode:)
+      site = Sanitizer.sanitized_site_name
+      channel = Sanitizer.sanitized_default_channel
+      frequency = Sanitizer.sanitized_default_frequency
+      matrix = Sanitizer.sanitized_matrix_room
+
+      summary = "Live Meshtastic mesh map for #{site}"
+      if channel.empty? && frequency.empty?
+        summary += "."
+      elsif channel.empty?
+        summary += " tuned to #{frequency}."
+      elsif frequency.empty?
+        summary += " on #{channel}."
+      else
+        summary += " on #{channel} (#{frequency})."
+      end
+
+      activity_sentence = if private_mode
+          "Track nodes and coverage in real time."
+        else
+          "Track nodes, messages, and coverage in real time."
+        end
+
+      sentences = [summary, activity_sentence]
+      if (distance = Sanitizer.sanitized_max_distance_km)
+        sentences << "Shows nodes within roughly #{formatted_distance_km(distance)} km of the map center."
+      end
+      sentences << "Join the community in #{matrix} on Matrix." if matrix
+
+      sentences.join(" ")
+    end
+
+    def configuration(private_mode:)
+      site = Sanitizer.sanitized_site_name
+      {
+        title: site,
+        name: site,
+        description: description(private_mode: private_mode),
+      }.freeze
+    end
+  end
+end

--- a/web/lib/potato_mesh/sanitizer.rb
+++ b/web/lib/potato_mesh/sanitizer.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "ipaddr"
+
+require_relative "config"
+
+module PotatoMesh
+  module Sanitizer
+    module_function
+
+    def string_or_nil(value)
+      return nil if value.nil?
+
+      str = value.is_a?(String) ? value : value.to_s
+      trimmed = str.strip
+      trimmed.empty? ? nil : trimmed
+    end
+
+    def sanitize_instance_domain(value)
+      host = string_or_nil(value)
+      return nil unless host
+
+      trimmed = host.strip
+      trimmed = trimmed.delete_suffix(".") while trimmed.end_with?(".")
+      return nil if trimmed.empty?
+      return nil if trimmed.match?(%r{[\s/\\@]})
+
+      trimmed
+    end
+
+    def instance_domain_host(domain)
+      return nil if domain.nil?
+
+      candidate = domain.strip
+      return nil if candidate.empty?
+
+      if candidate.start_with?("[")
+        match = candidate.match(/\A\[(?<host>[^\]]+)\](?::(?<port>\d+))?\z/)
+        return match[:host] if match
+        return nil
+      end
+
+      host, port = candidate.split(":", 2)
+      if port && !host.include?(":") && port.match?(/\A\d+\z/)
+        return host
+      end
+
+      candidate
+    end
+
+    def ip_from_domain(domain)
+      host = instance_domain_host(domain)
+      return nil unless host
+
+      IPAddr.new(host)
+    rescue IPAddr::InvalidAddressError
+      nil
+    end
+
+    def sanitized_string(value)
+      value.to_s.strip
+    end
+
+    def sanitized_site_name
+      sanitized_string(Config.site_name)
+    end
+
+    def sanitized_default_channel
+      sanitized_string(Config.default_channel)
+    end
+
+    def sanitized_default_frequency
+      sanitized_string(Config.default_frequency)
+    end
+
+    def sanitized_matrix_room
+      value = sanitized_string(Config.matrix_room)
+      value.empty? ? nil : value
+    end
+
+    def sanitized_max_distance_km
+      distance = Config.max_node_distance_km
+      return nil unless distance.is_a?(Numeric)
+      return nil unless distance.positive?
+
+      distance
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- extract configuration, sanitizer, and meta helpers into dedicated PotatoMesh modules
- update the Sinatra app to consume the new configuration APIs and freeze configuration hashes
- adjust specs to rely on PotatoMesh::Config helpers when accessing configuration

## Testing
- rufo .
- black .
- bundle exec rspec *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68eabfcec9cc832ba46adff5c6fcbd1b