### PR TITLE
Adjust federation announcement interval to eight hours

### DIFF
--- a/web/lib/potato_mesh/config.rb
+++ b/web/lib/potato_mesh/config.rb
@@ -133,8 +133,10 @@ module PotatoMesh
       ["potatomesh.net"].freeze
     end
 
+    # @return [Integer] the number of seconds between federation announcement broadcasts.
+    #   Eight hours provides three updates per day without creating unnecessary chatter.
     def federation_announcement_interval
-      24 * 60 * 60
+      8 * 60 * 60
     end
 
     def site_name

--- a/web/spec/config_spec.rb
+++ b/web/spec/config_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe PotatoMesh::Config do
+  describe ".federation_announcement_interval" do
+    it "returns eight hours in seconds" do
+      expect(described_class.federation_announcement_interval).to eq(8 * 60 * 60)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- document the federation announcement interval and reduce it to eight hours between broadcasts
- add a configuration spec ensuring the announcement cadence matches the new schedule

## Testing
- rufo .
- black .
- pytest
- bundle exec rspec
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68eb527c4258832b8fd2b522f20c09f9