### PR TITLE
Fix IPv6 instance domain canonicalization

### DIFF
--- a/web/spec/networking_spec.rb
+++ b/web/spec/networking_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe PotatoMesh::Application do
+  describe ".canonicalize_configured_instance_domain" do
+    subject(:canonicalize) { described_class.canonicalize_configured_instance_domain(input) }
+
+    context "with an IPv6 URL" do
+      let(:input) { "http://[::1]" }
+
+      it "retains brackets around the literal" do
+        expect(canonicalize).to eq("[::1]")
+      end
+    end
+
+    context "with an IPv6 URL including a non-default port" do
+      let(:input) { "http://[::1]:8080" }
+
+      it "keeps the literal bracketed and appends the port" do
+        expect(canonicalize).to eq("[::1]:8080")
+      end
+    end
+
+    context "with a bare IPv6 literal" do
+      let(:input) { "::1" }
+
+      it "wraps the literal in brackets" do
+        expect(canonicalize).to eq("[::1]")
+      end
+    end
+
+    context "with a bare IPv6 literal and port" do
+      let(:input) { "::1:9000" }
+
+      it "wraps the literal in brackets and preserves the port" do
+        expect(canonicalize).to eq("[::1]:9000")
+      end
+    end
+
+    context "with an IPv4 literal" do
+      let(:input) { "http://127.0.0.1" }
+
+      it "returns the literal without brackets" do
+        expect(canonicalize).to eq("127.0.0.1")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- preserve IPv6 literal brackets during instance domain canonicalization and retain explicit port values when provided
- add RSpec coverage for IPv6 URL, literal, and IPv4 canonicalization paths
- fix #289 

## Testing
- rufo .
- black .
- pytest
- bundle exec rspec
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68eb54ea5f20832b955bf08412b5a8bf