### PR TITLE
Update workflows for ingestor, sinatra, and frontend

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -4,8 +4,9 @@
 
 - **`docker.yml`** - Build and push Docker images to GHCR
 - **`codeql.yml`** - Security scanning
-- **`python.yml`** - Python testing
-- **`ruby.yml`** - Ruby testing
+- **`python.yml`** - Python ingestor pipeline
+- **`ruby.yml`** - Ruby Sinatra app testing
+- **`javascript.yml`** - Frontend test suite
 
 ## Usage
 

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -10,14 +10,14 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  frontend:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
-    - name: Set up Node.js 20
+    - name: Set up Node.js 22
       uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '22'
     - name: Install dependencies
       run: npm install
       working-directory: web
@@ -30,8 +30,8 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: web/reports/javascript-coverage.json
-        flags: javascript
-        name: javascript
+        flags: frontend
+        name: frontend
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     - name: Upload test results to Codecov
@@ -39,4 +39,4 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: web/reports/javascript-junit.xml
-        flags: javascript
+        flags: frontend

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -10,12 +10,12 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  ingestor:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
     - name: Set up Python 3.13
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: "3.13"
     - name: Install dependencies

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  sinatra:
     defaults:
       run:
         working-directory: ./web
@@ -42,13 +42,13 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./web/tmp/test-results/rspec.xml
-        flags: ruby-${{ matrix.ruby-version }}
+        flags: sinatra-${{ matrix.ruby-version }}
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: false
-        flags: ruby-${{ matrix.ruby-version }}
+        flags: sinatra-${{ matrix.ruby-version }}
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     - name: Run rufo

--- a/data/requirements.txt
+++ b/data/requirements.txt
@@ -1,7 +1,8 @@
 # Production dependencies
-meshtastic>=2.0.0
-protobuf>=4.21.12
+meshtastic>=2.5.0
+protobuf>=5.27.2
 
 # Development dependencies (optional)
-black>=23.0.0
-pytest>=7.0.0
+black>=24.8.0
+pytest>=8.3.0
+pytest-cov>=5.0.0


### PR DESCRIPTION
## Summary
- rename GitHub Actions jobs to ingestor, sinatra, and frontend while updating metadata and Codecov flags
- refresh workflow documentation to reflect the new job names
- bump Python dependency minimums for meshtastic, protobuf, pytest, and pytest-cov

## Testing
- pytest --cov=data --cov-report=term
- bundle exec rspec
- npm test
- black .
- bundle exec rufo .

------
https://chatgpt.com/codex/tasks/task_e_68eb573c89e8832baf0ea4534555131a