### PR TITLE
Document sanitization and helper modules

### DIFF
--- a/web/lib/potato_mesh/application.rb
+++ b/web/lib/potato_mesh/application.rb
@@ -81,6 +81,9 @@ module PotatoMesh
     SELF_INSTANCE_ID = Digest::SHA256.hexdigest(INSTANCE_PUBLIC_KEY_PEM)
     INSTANCE_DOMAIN, INSTANCE_DOMAIN_SOURCE = determine_instance_domain
 
+    # Adjust the runtime logger severity to match the DEBUG flag.
+    #
+    # @return [void]
     def self.apply_logger_level!
       logger = settings.logger
       return unless logger

--- a/web/lib/potato_mesh/application/errors.rb
+++ b/web/lib/potato_mesh/application/errors.rb
@@ -14,6 +14,7 @@
 
 module PotatoMesh
   module App
+    # Raised when a remote instance fails to provide valid federation data.
     class InstanceFetchError < StandardError; end
   end
 end

--- a/web/lib/potato_mesh/application/identity.rb
+++ b/web/lib/potato_mesh/application/identity.rb
@@ -15,6 +15,9 @@
 module PotatoMesh
   module App
     module Identity
+      # Resolve the current application version string using git metadata when available.
+      #
+      # @return [String] semantic version compatible identifier.
       def determine_app_version
         repo_root = File.expand_path("../../..", __dir__)
         git_dir = File.join(repo_root, ".git")
@@ -39,6 +42,9 @@ module PotatoMesh
         PotatoMesh::Config.version_fallback
       end
 
+      # Load the persisted instance private key or generate a new one when absent.
+      #
+      # @return [Array<OpenSSL::PKey::RSA, Boolean>] tuple of key and generation flag.
       def load_or_generate_instance_private_key
         keyfile_path = PotatoMesh::Config.keyfile_path
         FileUtils.mkdir_p(File.dirname(keyfile_path))
@@ -66,10 +72,16 @@ module PotatoMesh
         [key, true]
       end
 
+      # Return the directory used to store well-known documents.
+      #
+      # @return [String] absolute path to the staging directory.
       def well_known_directory
         PotatoMesh::Config.well_known_storage_root
       end
 
+      # Determine the absolute path to the well-known document file.
+      #
+      # @return [String] filesystem path for the JSON document.
       def well_known_file_path
         File.join(
           well_known_directory,
@@ -77,6 +89,9 @@ module PotatoMesh
         )
       end
 
+      # Remove legacy well-known artifacts from previous releases.
+      #
+      # @return [void]
       def cleanup_legacy_well_known_artifacts
         legacy_path = PotatoMesh::Config.legacy_public_well_known_path
         FileUtils.rm_f(legacy_path)
@@ -87,6 +102,9 @@ module PotatoMesh
         # or file did not exist or is in use.
       end
 
+      # Construct the JSON body and detached signature for the well-known document.
+      #
+      # @return [Array(String, String)] pair of JSON output and base64 signature.
       def build_well_known_document
         last_update = latest_node_update_timestamp
         payload = {
@@ -112,6 +130,9 @@ module PotatoMesh
         [json_output, signature]
       end
 
+      # Regenerate the well-known document when the on-disk copy is stale.
+      #
+      # @return [void]
       def refresh_well_known_document_if_stale
         FileUtils.mkdir_p(well_known_directory)
         path = well_known_file_path
@@ -145,6 +166,9 @@ module PotatoMesh
         )
       end
 
+      # Retrieve the latest node update timestamp from the database.
+      #
+      # @return [Integer, nil] Unix timestamp or nil when unavailable.
       def latest_node_update_timestamp
         return nil unless File.exist?(PotatoMesh::Config.db_path)
 
@@ -159,6 +183,9 @@ module PotatoMesh
         db&.close
       end
 
+      # Emit a debug entry describing the active instance key material.
+      #
+      # @return [void]
       def log_instance_public_key
         debug_log(
           "Loaded instance public key",
@@ -174,6 +201,9 @@ module PotatoMesh
         end
       end
 
+      # Emit a debug entry describing how the instance domain was derived.
+      #
+      # @return [void]
       def log_instance_domain_resolution
         source = app_constant(:INSTANCE_DOMAIN_SOURCE) || :unknown
         debug_log(

--- a/web/lib/potato_mesh/config.rb
+++ b/web/lib/potato_mesh/config.rb
@@ -13,45 +13,78 @@
 # frozen_string_literal: true
 
 module PotatoMesh
+  # Configuration wrapper responsible for exposing ENV backed settings used by
+  # the web and data ingestion services.
   module Config
     module_function
 
+    # Resolve the absolute path to the web application root directory.
+    #
+    # @return [String] absolute filesystem path of the web folder.
     def web_root
       @web_root ||= File.expand_path("../..", __dir__)
     end
 
+    # Resolve the repository root directory relative to the web folder.
+    #
+    # @return [String] path to the Git repository root.
     def repo_root
       @repo_root ||= File.expand_path("..", web_root)
     end
 
+    # Build the default SQLite database path inside the data directory.
+    #
+    # @return [String] absolute path to +data/mesh.db+.
     def default_db_path
       File.expand_path("../data/mesh.db", web_root)
     end
 
+    # Determine the configured database location, defaulting to the bundled
+    # SQLite file.
+    #
+    # @return [String] absolute path to the database file.
     def db_path
       ENV.fetch("MESH_DB", default_db_path)
     end
 
+    # Retrieve the SQLite busy timeout duration in milliseconds.
+    #
+    # @return [Integer] timeout value in milliseconds.
     def db_busy_timeout_ms
       ENV.fetch("DB_BUSY_TIMEOUT_MS", "5000").to_i
     end
 
+    # Retrieve the maximum number of retries when encountering SQLITE_BUSY.
+    #
+    # @return [Integer] maximum retry attempts.
     def db_busy_max_retries
       ENV.fetch("DB_BUSY_MAX_RETRIES", "5").to_i
     end
 
+    # Retrieve the backoff delay between busy retries in seconds.
+    #
+    # @return [Float] seconds to wait between retries.
     def db_busy_retry_delay
       ENV.fetch("DB_BUSY_RETRY_DELAY", "0.05").to_f
     end
 
+    # Convenience constant describing the number of seconds in a week.
+    #
+    # @return [Integer] seconds in seven days.
     def week_seconds
       7 * 24 * 60 * 60
     end
 
+    # Default upper bound for accepted JSON payload sizes.
+    #
+    # @return [Integer] byte ceiling for HTTP request bodies.
     def default_max_json_body_bytes
       1_048_576
     end
 
+    # Determine the maximum allowed JSON body size with validation.
+    #
+    # @return [Integer] configured byte limit.
     def max_json_body_bytes
       raw = ENV.fetch("MAX_JSON_BODY_BYTES", default_max_json_body_bytes.to_s)
       value = Integer(raw, 10)
@@ -60,14 +93,23 @@ module PotatoMesh
       default_max_json_body_bytes
     end
 
+    # Provide the fallback version string when git metadata is unavailable.
+    #
+    # @return [String] semantic version identifier.
     def version_fallback
       "v0.5.0"
     end
 
+    # Default refresh interval for frontend polling routines.
+    #
+    # @return [Integer] refresh period in seconds.
     def default_refresh_interval_seconds
       60
     end
 
+    # Fetch the refresh interval, ensuring a positive integer value.
+    #
+    # @return [Integer] polling cadence in seconds.
     def refresh_interval_seconds
       raw = ENV.fetch("REFRESH_INTERVAL_SECONDS", default_refresh_interval_seconds.to_s)
       value = Integer(raw, 10)
@@ -76,6 +118,9 @@ module PotatoMesh
       default_refresh_interval_seconds
     end
 
+    # Retrieve the CSS filter used for light themed maps.
+    #
+    # @return [String] CSS filter string.
     def map_tile_filter_light
       ENV.fetch(
         "MAP_TILE_FILTER_LIGHT",
@@ -83,6 +128,9 @@ module PotatoMesh
       )
     end
 
+    # Retrieve the CSS filter used for dark themed maps.
+    #
+    # @return [String] CSS filter string for dark tiles.
     def map_tile_filter_dark
       ENV.fetch(
         "MAP_TILE_FILTER_DARK",
@@ -90,6 +138,9 @@ module PotatoMesh
       )
     end
 
+    # Provide a simple hash of tile filters for template use.
+    #
+    # @return [Hash] frozen mapping of themes to CSS filters.
     def tile_filters
       {
         light: map_tile_filter_light,
@@ -97,92 +148,159 @@ module PotatoMesh
       }.freeze
     end
 
+    # Retrieve the raw comma separated Prometheus report identifiers.
+    #
+    # @return [String] comma separated list of report IDs.
     def prom_report_ids
       ENV.fetch("PROM_REPORT_IDS", "")
     end
 
+    # Transform Prometheus report identifiers into a cleaned array.
+    #
+    # @return [Array<String>] list of unique report identifiers.
     def prom_report_id_list
       prom_report_ids.split(",").map(&:strip).reject(&:empty?)
     end
 
+    # Path storing the instance private key used for signing.
+    #
+    # @return [String] absolute location of the PEM file.
     def keyfile_path
       File.join(web_root, ".config", "keyfile")
     end
 
+    # Sub-path used when exposing well known configuration files.
+    #
+    # @return [String] relative path within the public directory.
     def well_known_relative_path
       File.join(".well-known", "potato-mesh")
     end
 
+    # Filesystem directory used to stage /.well-known artifacts.
+    #
+    # @return [String] absolute storage path.
     def well_known_storage_root
       File.join(web_root, ".config", "well-known")
     end
 
+    # Legacy location for well known assets within the public folder.
+    #
+    # @return [String] absolute path to the legacy output directory.
     def legacy_public_well_known_path
       File.join(web_root, "public", well_known_relative_path)
     end
 
+    # Interval used to refresh well known documents from disk.
+    #
+    # @return [Integer] refresh duration in seconds.
     def well_known_refresh_interval
       24 * 60 * 60
     end
 
+    # Cryptographic algorithm identifier for HTTP signatures.
+    #
+    # @return [String] RFC-compliant algorithm label.
     def instance_signature_algorithm
       "rsa-sha256"
     end
 
+    # Timeout used when querying remote instances during federation.
+    #
+    # @return [Integer] HTTP timeout in seconds.
     def remote_instance_http_timeout
       5
     end
 
+    # Maximum acceptable age for remote node data.
+    #
+    # @return [Integer] seconds before remote nodes are considered stale.
     def remote_instance_max_node_age
       86_400
     end
 
+    # Minimum node count expected from a remote instance before storing.
+    #
+    # @return [Integer] node threshold for remote ingestion.
     def remote_instance_min_node_count
       10
     end
 
+    # Domains used to seed the federation discovery process.
+    #
+    # @return [Array<String>] list of default seed domains.
     def federation_seed_domains
       ["potatomesh.net"].freeze
     end
 
-    # @return [Integer] the number of seconds between federation announcement broadcasts.
-    #   Eight hours provides three updates per day without creating unnecessary chatter.
+    # Determine how often we broadcast federation announcements.
+    #
+    # @return [Integer] number of seconds between announcement cycles.
     def federation_announcement_interval
       8 * 60 * 60
     end
 
+    # Retrieve the configured site name for presentation.
+    #
+    # @return [String] human friendly site label.
     def site_name
       fetch_string("SITE_NAME", "PotatoMesh Demo")
     end
 
+    # Retrieve the default radio channel label.
+    #
+    # @return [String] channel name from configuration.
     def default_channel
       fetch_string("DEFAULT_CHANNEL", "#LongFast")
     end
 
+    # Retrieve the default radio frequency description.
+    #
+    # @return [String] frequency identifier.
     def default_frequency
       fetch_string("DEFAULT_FREQUENCY", "915MHz")
     end
 
+    # Map display latitude centre for the frontend map widget.
+    #
+    # @return [Float] latitude in decimal degrees.
     def map_center_lat
       ENV.fetch("MAP_CENTER_LAT", "38.761944").to_f
     end
 
+    # Map display longitude centre for the frontend map widget.
+    #
+    # @return [Float] longitude in decimal degrees.
     def map_center_lon
       ENV.fetch("MAP_CENTER_LON", "-27.090833").to_f
     end
 
+    # Maximum straight-line distance between nodes before relationships are
+    # hidden.
+    #
+    # @return [Float] distance in kilometres.
     def max_node_distance_km
       ENV.fetch("MAX_NODE_DISTANCE_KM", "42").to_f
     end
 
+    # Matrix room identifier for community discussion.
+    #
+    # @return [String] Matrix room alias.
     def matrix_room
       ENV.fetch("MATRIX_ROOM", "#potatomesh:dod.ngo")
     end
 
+    # Check whether verbose debugging is enabled for the runtime.
+    #
+    # @return [Boolean] true when DEBUG=1.
     def debug?
       ENV["DEBUG"] == "1"
     end
 
+    # Fetch and sanitise string based configuration values.
+    #
+    # @param key [String] environment variable to read.
+    # @param default [String] fallback value when unset or blank.
+    # @return [String] cleaned configuration string.
     def fetch_string(key, default)
       value = ENV[key]
       return default if value.nil?

--- a/web/lib/potato_mesh/meta.rb
+++ b/web/lib/potato_mesh/meta.rb
@@ -16,13 +16,22 @@ require_relative "config"
 require_relative "sanitizer"
 
 module PotatoMesh
+  # Helper functions used to generate SEO metadata and formatted values.
   module Meta
     module_function
 
+    # Format a distance in kilometres without trailing decimal precision when unnecessary.
+    #
+    # @param distance [Numeric] distance in kilometres.
+    # @return [String] formatted kilometre value.
     def formatted_distance_km(distance)
       format("%.1f", distance).sub(/\.0\z/, "")
     end
 
+    # Construct the meta description string displayed to search engines and social previews.
+    #
+    # @param private_mode [Boolean] whether private mode is enabled.
+    # @return [String] generated description text.
     def description(private_mode:)
       site = Sanitizer.sanitized_site_name
       channel = Sanitizer.sanitized_default_channel
@@ -55,6 +64,10 @@ module PotatoMesh
       sentences.join(" ")
     end
 
+    # Build a hash of meta configuration values used by templating layers.
+    #
+    # @param private_mode [Boolean] whether private mode is enabled.
+    # @return [Hash] structured metadata for templates.
     def configuration(private_mode:)
       site = Sanitizer.sanitized_site_name
       {


### PR DESCRIPTION
## Summary
- add RDoc documentation to configuration, sanitization, and metadata utilities
- document application helper, networking, identity, and database modules to clarify behaviour
- annotate the Sinatra application logger configuration

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'meshtastic.protobuf')*
- bundle exec rspec
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68eb5ed221e0832bbe78f82b8d0b7226