### PR TITLE
Increase coverage for configuration and sanitizer helpers

### DIFF
--- a/web/spec/config_spec.rb
+++ b/web/spec/config_spec.rb
@@ -20,4 +20,140 @@ RSpec.describe PotatoMesh::Config do
       expect(described_class.federation_announcement_interval).to eq(8 * 60 * 60)
     end
   end
+
+  describe ".db_path" do
+    it "uses the environment override when available" do
+      within_env("MESH_DB" => "/tmp/spec.db") do
+        expect(described_class.db_path).to eq("/tmp/spec.db")
+      end
+    end
+
+    it "falls back to the bundled database path" do
+      within_env("MESH_DB" => nil) do
+        expect(described_class.db_path).to eq(described_class.default_db_path)
+      end
+    end
+  end
+
+  describe ".max_json_body_bytes" do
+    it "returns the default when the value is missing" do
+      within_env("MAX_JSON_BODY_BYTES" => nil) do
+        expect(described_class.max_json_body_bytes).to eq(
+          described_class.default_max_json_body_bytes,
+        )
+      end
+    end
+
+    it "returns the parsed integer when valid" do
+      within_env("MAX_JSON_BODY_BYTES" => "2048") do
+        expect(described_class.max_json_body_bytes).to eq(2048)
+      end
+    end
+
+    it "rejects invalid and non-positive values" do
+      within_env("MAX_JSON_BODY_BYTES" => "potato") do
+        expect(described_class.max_json_body_bytes).to eq(
+          described_class.default_max_json_body_bytes,
+        )
+      end
+
+      within_env("MAX_JSON_BODY_BYTES" => "0") do
+        expect(described_class.max_json_body_bytes).to eq(
+          described_class.default_max_json_body_bytes,
+        )
+      end
+    end
+  end
+
+  describe ".refresh_interval_seconds" do
+    it "returns the default when the configuration is invalid" do
+      within_env("REFRESH_INTERVAL_SECONDS" => "invalid") do
+        expect(described_class.refresh_interval_seconds).to eq(
+          described_class.default_refresh_interval_seconds,
+        )
+      end
+    end
+
+    it "honours positive integer overrides" do
+      within_env("REFRESH_INTERVAL_SECONDS" => "120") do
+        expect(described_class.refresh_interval_seconds).to eq(120)
+      end
+    end
+
+    it "rejects zero or negative overrides" do
+      within_env("REFRESH_INTERVAL_SECONDS" => "0") do
+        expect(described_class.refresh_interval_seconds).to eq(
+          described_class.default_refresh_interval_seconds,
+        )
+      end
+    end
+  end
+
+  describe ".prom_report_id_list" do
+    it "splits and normalises identifiers" do
+      within_env("PROM_REPORT_IDS" => " alpha , beta,, ") do
+        expect(described_class.prom_report_id_list).to eq(%w[alpha beta])
+      end
+    end
+  end
+
+  describe ".fetch_string" do
+    it "trims whitespace and falls back when blank" do
+      within_env("SITE_NAME" => "  \t  ") do
+        expect(described_class.site_name).to eq("PotatoMesh Demo")
+      end
+
+      within_env("SITE_NAME" => "  Spec Mesh  ") do
+        expect(described_class.site_name).to eq("Spec Mesh")
+      end
+    end
+  end
+
+  describe ".debug?" do
+    it "reflects the DEBUG environment variable" do
+      within_env("DEBUG" => "1") do
+        expect(described_class.debug?).to be(true)
+      end
+
+      within_env("DEBUG" => nil) do
+        expect(described_class.debug?).to be(false)
+      end
+    end
+  end
+
+  describe ".tile_filters" do
+    it "returns a frozen mapping" do
+      filters = described_class.tile_filters
+
+      expect(filters).to match(light: String, dark: String)
+      expect(filters).to be_frozen
+    end
+  end
+
+  # Execute the provided block with temporary environment overrides.
+  #
+  # @param values [Hash{String=>String, nil}] key/value pairs to set in ENV.
+  # @yield [] block executed while the overrides are active.
+  # @return [void]
+  def within_env(values)
+    original = {}
+    values.each do |key, value|
+      original[key] = ENV.key?(key) ? ENV[key] : :__unset__
+      if value.nil?
+        ENV.delete(key)
+      else
+        ENV[key] = value
+      end
+    end
+
+    yield
+  ensure
+    original.each do |key, value|
+      if value == :__unset__
+        ENV.delete(key)
+      else
+        ENV[key] = value
+      end
+    end
+  end
 end

--- a/web/spec/sanitizer_spec.rb
+++ b/web/spec/sanitizer_spec.rb
@@ -1,0 +1,104 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# frozen_string_literal: true
+
+require "spec_helper"
+require "ipaddr"
+require "potato_mesh/sanitizer"
+
+RSpec.describe PotatoMesh::Sanitizer do
+  describe ".string_or_nil" do
+    it "returns trimmed strings or nil" do
+      expect(described_class.string_or_nil("  value \n")).to eq("value")
+      expect(described_class.string_or_nil(" \t ")).to be_nil
+      expect(described_class.string_or_nil(nil)).to be_nil
+      expect(described_class.string_or_nil(123)).to eq("123")
+    end
+  end
+
+  describe ".sanitize_instance_domain" do
+    it "rejects invalid domains" do
+      expect(described_class.sanitize_instance_domain(nil)).to be_nil
+      expect(described_class.sanitize_instance_domain(" ")).to be_nil
+      expect(described_class.sanitize_instance_domain("example.org/")).to be_nil
+      expect(described_class.sanitize_instance_domain("example .org")).to be_nil
+    end
+
+    it "normalises valid domains" do
+      expect(described_class.sanitize_instance_domain(" Example.Org. ")).to eq("Example.Org")
+      expect(described_class.sanitize_instance_domain("[::1]")).to eq("[::1]")
+    end
+  end
+
+  describe ".instance_domain_host" do
+    it "extracts hosts from literal and host:port values" do
+      expect(described_class.instance_domain_host("example.com:443")).to eq("example.com")
+      expect(described_class.instance_domain_host("[::1]:9000")).to eq("::1")
+      expect(described_class.instance_domain_host("::1")).to eq("::1")
+      expect(described_class.instance_domain_host("bad:port:name")).to eq("bad:port:name")
+      expect(described_class.instance_domain_host("[::1:invalid")).to be_nil
+    end
+  end
+
+  describe ".ip_from_domain" do
+    it "parses valid IP literals and rejects hostnames" do
+      expect(described_class.ip_from_domain("127.0.0.1")).to eq(IPAddr.new("127.0.0.1"))
+      expect(described_class.ip_from_domain("[2001:db8::1]:443")).to eq(IPAddr.new("2001:db8::1"))
+      expect(described_class.ip_from_domain("example.org")).to be_nil
+    end
+  end
+
+  describe "sanitised configuration accessors" do
+    before do
+      allow(PotatoMesh::Config).to receive_messages(
+        site_name: "  Spec Mesh  ",
+        default_channel: "  #Spec  ",
+        default_frequency: " 915MHz  ",
+        matrix_room: "  #room:example.org  ",
+        max_node_distance_km: 42,
+      )
+    end
+
+    it "provides trimmed strings" do
+      expect(described_class.sanitized_site_name).to eq("Spec Mesh")
+      expect(described_class.sanitized_default_channel).to eq("#Spec")
+      expect(described_class.sanitized_default_frequency).to eq("915MHz")
+      expect(described_class.sanitized_matrix_room).to eq("#room:example.org")
+      expect(described_class.sanitized_max_distance_km).to eq(42)
+    end
+
+    it "returns nil when the matrix room is blank" do
+      allow(PotatoMesh::Config).to receive(:matrix_room).and_return(" \t ")
+
+      expect(described_class.sanitized_matrix_room).to be_nil
+    end
+
+    it "returns nil when the distance is not positive" do
+      allow(PotatoMesh::Config).to receive(:max_node_distance_km).and_return(0)
+
+      expect(described_class.sanitized_max_distance_km).to be_nil
+    end
+
+    it "returns nil when the distance is not numeric" do
+      allow(PotatoMesh::Config).to receive(:max_node_distance_km).and_return("far")
+
+      expect(described_class.sanitized_max_distance_km).to be_nil
+    end
+  end
+
+  describe ".sanitized_string" do
+    it "always returns a string representation" do
+      expect(described_class.sanitized_string(:symbol)).to eq("symbol")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add comprehensive RSpec coverage for PotatoMesh::Config environment-driven helpers
- introduce dedicated sanitizer specs to exercise domain parsing and configuration coercion branches

## Testing
- rufo .
- black .
- pytest
- bundle exec rspec
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68eb71c85b04832b95cd37296c252eef