### PR TITLE
Fix Leaflet map rendering on mobile Safari

### DIFF
--- a/web/public/assets/js/app/__tests__/browser-capabilities.test.js
+++ b/web/public/assets/js/app/__tests__/browser-capabilities.test.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2025 l5yth
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { supportsLeafletTileContainerFilters } from '../browser-capabilities.js';
+
+const IPHONE_USER_AGENT =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1';
+const IPAD_USER_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.3 Mobile/15E148 Safari/604.1';
+const DESKTOP_SAFARI_USER_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 13_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15';
+const CHROME_USER_AGENT =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36';
+
+/**
+ * Create a minimal environment stub exposing only the navigator fields used by
+ * {@link supportsLeafletTileContainerFilters}.
+ *
+ * @param {Partial<Navigator>} navigatorOverrides Navigator property overrides.
+ * @returns {{ navigator: Partial<Navigator> }} Environment shim.
+ */
+function createEnvironment(navigatorOverrides) {
+  return { navigator: { ...navigatorOverrides } };
+}
+
+test('supportsLeafletTileContainerFilters defaults to safe behaviour', () => {
+  assert.equal(supportsLeafletTileContainerFilters(), true);
+  assert.equal(supportsLeafletTileContainerFilters(undefined), true);
+  assert.equal(supportsLeafletTileContainerFilters({}), true);
+});
+
+test('mobile Safari environments disable container filters', () => {
+  const iphoneEnv = createEnvironment({ userAgent: IPHONE_USER_AGENT, platform: 'iPhone', maxTouchPoints: 5 });
+  assert.equal(supportsLeafletTileContainerFilters(iphoneEnv), false);
+
+  const ipadEnv = createEnvironment({ userAgent: IPAD_USER_AGENT, platform: 'MacIntel', maxTouchPoints: 5 });
+  assert.equal(supportsLeafletTileContainerFilters(ipadEnv), false);
+});
+
+test('desktop browsers retain container filter support', () => {
+  const safariEnv = createEnvironment({ userAgent: DESKTOP_SAFARI_USER_AGENT, platform: 'MacIntel', maxTouchPoints: 0 });
+  assert.equal(supportsLeafletTileContainerFilters(safariEnv), true);
+
+  const chromeEnv = createEnvironment({ userAgent: CHROME_USER_AGENT, platform: 'Win32', maxTouchPoints: 0 });
+  assert.equal(supportsLeafletTileContainerFilters(chromeEnv), true);
+});

--- a/web/public/assets/js/app/browser-capabilities.js
+++ b/web/public/assets/js/app/browser-capabilities.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2025 l5yth
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Determine whether the current browser safely supports CSS filter effects on
+ * Leaflet tile container elements.
+ *
+ * Safari on iOS and iPadOS mis-renders filtered containers by painting them
+ * black. When this function returns {@code false} the application should avoid
+ * applying filters beyond individual tile elements.
+ *
+ * @param {Pick<Window, 'navigator'>|undefined} environment Host environment or
+ *        a lightweight shim containing a {@link Navigator} reference. Defaults
+ *        to {@link globalThis} when omitted.
+ * @returns {boolean} {@code true} when it is safe to filter container
+ *          elements; {@code false} when filters should be limited to individual
+ *          tiles.
+ */
+export function supportsLeafletTileContainerFilters(environment = globalThis) {
+  const navigatorRef = environment?.navigator;
+  if (!navigatorRef) {
+    return true;
+  }
+
+  const userAgent = typeof navigatorRef.userAgent === 'string' ? navigatorRef.userAgent : '';
+  const platform = typeof navigatorRef.platform === 'string' ? navigatorRef.platform : '';
+  const touchPoints = typeof navigatorRef.maxTouchPoints === 'number' ? navigatorRef.maxTouchPoints : 0;
+
+  const isIosDevice = /\b(iPad|iPhone|iPod)\b/i.test(userAgent);
+  const isIpadOsDevice = platform === 'MacIntel' && touchPoints > 1 && /\bAppleWebKit\b/i.test(userAgent);
+
+  return !(isIosDevice || isIpadOsDevice);
+}
+
+export const __testHooks = Object.freeze({ supportsLeafletTileContainerFilters });

--- a/web/public/assets/js/app/main.js
+++ b/web/public/assets/js/app/main.js
@@ -15,6 +15,7 @@
  */
 
 import { computeBoundingBox, computeBoundsForPoints, haversineDistanceKm } from './map-bounds.js';
+import { supportsLeafletTileContainerFilters } from './browser-capabilities.js';
 
 /**
  * Entry point for the interactive dashboard. Wires up event listeners,
@@ -274,6 +275,14 @@ export function initializeApp(config) {
   const mapPanel = document.getElementById('mapPanel');
   const mapFullscreenToggle = document.getElementById('mapFullscreenToggle');
   const fullscreenContainer = mapPanel || mapContainer;
+  /**
+   * Pre-compute whether the browser safely supports applying CSS filters to
+   * Leaflet tile container elements. Mobile Safari renders filtered containers
+   * as an opaque black rectangle, so we avoid those operations when detected.
+   */
+  const containerFiltersSupported = supportsLeafletTileContainerFilters(
+    typeof window !== 'undefined' ? window : undefined
+  );
   let mapStatusEl = null;
   let map = null;
   let mapCenterLatLng = null;
@@ -704,7 +713,7 @@ export function initializeApp(config) {
    * @returns {void}
    */
   function applyFilterToTileContainers(filterValue) {
-    if (!map) return;
+    if (!map || !containerFiltersSupported) return;
     const value = filterValue || resolveTileFilter();
     const container = getActiveTileLayerContainer();
     if (container && container.style) {

--- a/web/public/assets/styles/base.css
+++ b/web/public/assets/styles/base.css
@@ -727,6 +727,9 @@ input[type="radio"] {
 #map .leaflet-layer,
 #map .leaflet-tile.map-tiles {
   opacity: 0.75;
+}
+
+#map .leaflet-tile.map-tiles {
   filter: var(--map-tiles-filter, var(--map-tile-filter-light));
   -webkit-filter: var(--map-tiles-filter, var(--map-tile-filter-light));
 }
@@ -1090,15 +1093,11 @@ body.dark .short-info-overlay .short-info-close:hover {
   background: rgba(255, 255, 255, 0.1);
 }
 
-#map .leaflet-tile-pane,
-#map .leaflet-layer,
 #map .leaflet-tile.map-tiles {
   filter: var(--map-tiles-filter, var(--map-tile-filter-light));
   -webkit-filter: var(--map-tiles-filter, var(--map-tile-filter-light));
 }
 
-body.dark #map .leaflet-tile-pane,
-body.dark #map .leaflet-layer,
 body.dark #map .leaflet-tile.map-tiles {
   filter: var(--map-tiles-filter, var(--map-tile-filter-dark));
   -webkit-filter: var(--map-tiles-filter, var(--map-tile-filter-dark));


### PR DESCRIPTION
## Summary
- avoid applying Leaflet tile container filters on iOS/iPadOS Safari to prevent black maps
- adjust map styles to scope CSS filters to tile elements while keeping existing opacity styling
- add a browser capability helper module with targeted unit coverage

## Testing
- npm test
- pytest
- bundle exec rspec
- rufo .
- black .

------
https://chatgpt.com/codex/tasks/task_e_68ebe431f888832b8881ee0635788d2e