### PR TITLE
Fix Leaflet map container layout on mobile

### DIFF
--- a/web/public/assets/styles/base.css
+++ b/web/public/assets/styles/base.css
@@ -167,9 +167,6 @@ h1 {
   border: 1px solid #ddd;
   border-radius: 8px;
   overflow: hidden;
-  display: flex;
-  align-items: center;
-  justify-content: center;
 }
 
 .map-panel.is-fullscreen,
@@ -233,6 +230,9 @@ h1 {
 }
 
 #map[data-map-status="placeholder"] {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   background: repeating-linear-gradient(
     135deg,
     rgba(0, 0, 0, 0.02),


### PR DESCRIPTION
## Summary
- stop using a flex layout for the Leaflet map container to restore tile rendering on small screens
- keep placeholder messaging centered by only applying flex layout when the placeholder state is active

## Testing
- black .
- rufo .
- pytest
- rspec
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68ebe5d3e84c832b85decfe981eabccf