### PR TITLE
Adjust map auto-fit padding and default zoom

### DIFF
--- a/web/public/assets/js/app/main.js
+++ b/web/public/assets/js/app/main.js
@@ -284,9 +284,9 @@ export function initializeApp(config) {
   const MAX_NODE_DISTANCE_KM = Number.isFinite(config.maxNodeDistanceKm) && config.maxNodeDistanceKm > 0
     ? config.maxNodeDistanceKm
     : 1;
-  const INITIAL_VIEW_PADDING_PX = 48;
-  const AUTO_FIT_PADDING_PX = 56;
-  const MAX_INITIAL_ZOOM = 12;
+  const INITIAL_VIEW_PADDING_PX = 12;
+  const AUTO_FIT_PADDING_PX = 12;
+  const MAX_INITIAL_ZOOM = 13;
   let neighborLinesLayer = null;
   let neighborLinesVisible = true;
   let neighborLinesToggleButton = null;
@@ -315,7 +315,7 @@ export function initializeApp(config) {
    */
   function fitMapToBounds(bounds, options = {}) {
     if (!map || !bounds) return;
-    const padding = Number.isFinite(options.paddingPx) && options.paddingPx >= 0 ? options.paddingPx : 32;
+    const padding = Number.isFinite(options.paddingPx) && options.paddingPx >= 0 ? options.paddingPx : AUTO_FIT_PADDING_PX;
     const fitOptions = {
       animate: Boolean(options.animate),
       padding: [padding, padding]


### PR DESCRIPTION
## Summary
- decrease the map auto-fit padding defaults to significantly tighten map margins
- raise the initial maximum auto-fit zoom level to start one level closer
- reuse the reduced padding constant whenever fit bounds uses a fallback

## Testing
- black .
- rufo .
- pytest
- bundle exec rspec
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68ecb7d4825c832b9bc37821a39c330e