### PR TITLE
Fix FrozenError when filtering node query results

### DIFF
--- a/web/lib/potato_mesh/application/queries.rb
+++ b/web/lib/potato_mesh/application/queries.rb
@@ -159,7 +159,7 @@ module PotatoMesh
         params << limit
 
         rows = db.execute(sql, params)
-        rows.select! do |r|
+        rows = rows.select do |r|
           last_candidate = [r["last_heard"], r["position_time"], r["first_heard"]]
             .map { |value| coerce_integer(value) }
             .compact


### PR DESCRIPTION
## Summary
- avoid mutating SQLite query result sets in `query_nodes` to prevent FrozenError when rows are frozen

## Testing
- rufo .
- black .
- pytest
- bundle exec rspec
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ed159dd5f0832b980109c6b22b0e64