### PR TITLE
Adjust node table columns responsively

### DIFF
--- a/web/public/assets/js/app/main.js
+++ b/web/public/assets/js/app/main.js
@@ -2581,24 +2581,24 @@ export function initializeApp(config) {
       const lastPositionTime = toFiniteNumber(n.position_time ?? n.positionTime);
       const lastPositionCell = lastPositionTime != null ? timeAgo(lastPositionTime, nowSec) : '';
       tr.innerHTML = `
-        <td class="mono">${n.node_id || ""}</td>
-        <td>${renderShortHtml(n.short_name, n.role, n.long_name, n)}</td>
-        <td>${n.long_name || ""}</td>
-        <td>${timeAgo(n.last_heard, nowSec)}</td>
-        <td>${n.role || "CLIENT"}</td>
-        <td>${fmtHw(n.hw_model)}</td>
-        <td>${fmtAlt(n.battery_level, "%")}</td>
-        <td>${fmtAlt(n.voltage, "V")}</td>
-        <td>${timeHum(n.uptime_seconds)}</td>
-        <td>${fmtTx(n.channel_utilization)}</td>
-        <td>${fmtTx(n.air_util_tx)}</td>
-        <td>${fmtTemperature(n.temperature)}</td>
-        <td>${fmtHumidity(n.relative_humidity)}</td>
-        <td>${fmtPressure(n.barometric_pressure)}</td>
-        <td>${fmtCoords(n.latitude)}</td>
-        <td>${fmtCoords(n.longitude)}</td>
-        <td>${fmtAlt(n.altitude, "m")}</td>
-        <td class="mono">${lastPositionCell}</td>`;
+        <td class="mono nodes-col nodes-col--node-id">${n.node_id || ""}</td>
+        <td class="nodes-col nodes-col--short-name">${renderShortHtml(n.short_name, n.role, n.long_name, n)}</td>
+        <td class="nodes-col nodes-col--long-name">${n.long_name || ""}</td>
+        <td class="nodes-col nodes-col--last-seen">${timeAgo(n.last_heard, nowSec)}</td>
+        <td class="nodes-col nodes-col--role">${n.role || "CLIENT"}</td>
+        <td class="nodes-col nodes-col--hw-model">${fmtHw(n.hw_model)}</td>
+        <td class="nodes-col nodes-col--battery">${fmtAlt(n.battery_level, "%")}</td>
+        <td class="nodes-col nodes-col--voltage">${fmtAlt(n.voltage, "V")}</td>
+        <td class="nodes-col nodes-col--uptime">${timeHum(n.uptime_seconds)}</td>
+        <td class="nodes-col nodes-col--channel-util">${fmtTx(n.channel_utilization)}</td>
+        <td class="nodes-col nodes-col--air-util-tx">${fmtTx(n.air_util_tx)}</td>
+        <td class="nodes-col nodes-col--temperature">${fmtTemperature(n.temperature)}</td>
+        <td class="nodes-col nodes-col--humidity">${fmtHumidity(n.relative_humidity)}</td>
+        <td class="nodes-col nodes-col--pressure">${fmtPressure(n.barometric_pressure)}</td>
+        <td class="nodes-col nodes-col--latitude">${fmtCoords(n.latitude)}</td>
+        <td class="nodes-col nodes-col--longitude">${fmtCoords(n.longitude)}</td>
+        <td class="nodes-col nodes-col--altitude">${fmtAlt(n.altitude, "m")}</td>
+        <td class="mono nodes-col nodes-col--last-position">${lastPositionCell}</td>`;
       frag.appendChild(tr);
     }
     tb.replaceChildren(frag);

--- a/web/public/assets/styles/base.css
+++ b/web/public/assets/styles/base.css
@@ -882,19 +882,6 @@ input[type="radio"] {
   word-break: break-word;
 }
 
-@media (max-width: 1280px) {
-  #nodes th:nth-child(15),
-  #nodes td:nth-child(15),
-  #nodes th:nth-child(16),
-  #nodes td:nth-child(16),
-  #nodes th:nth-child(17),
-  #nodes td:nth-child(17),
-  #nodes th:nth-child(18),
-  #nodes td:nth-child(18) {
-    display: none;
-  }
-}
-
 @media (max-width: 1024px) {
   .row {
     flex-direction: column;
@@ -960,33 +947,54 @@ input[type="radio"] {
     height: 30vh;
   }
 
-  #nodes th:nth-child(1),
-  #nodes td:nth-child(1),
-  #nodes th:nth-child(5),
-  #nodes td:nth-child(5),
-  #nodes th:nth-child(6),
-  #nodes td:nth-child(6),
-  #nodes th:nth-child(9),
-  #nodes td:nth-child(9),
-  #nodes th:nth-child(11),
-  #nodes td:nth-child(11),
-  #nodes th:nth-child(13),
-  #nodes td:nth-child(13),
-  #nodes th:nth-child(14),
-  #nodes td:nth-child(14),
-  #nodes th:nth-child(15),
-  #nodes td:nth-child(15),
-  #nodes th:nth-child(16),
-  #nodes td:nth-child(16),
-  #nodes th:nth-child(17),
-  #nodes td:nth-child(17),
-  #nodes th:nth-child(18),
-  #nodes td:nth-child(18) {
-    display: none;
-  }
-
   .legend {
     max-width: min(240px, 80vw);
+  }
+}
+
+@media (max-width: 1679px) {
+  .nodes-col--node-id {
+    display: none;
+  }
+}
+
+@media (max-width: 1559px) {
+  .nodes-col--temperature,
+  .nodes-col--humidity,
+  .nodes-col--pressure {
+    display: none;
+  }
+}
+
+@media (max-width: 1319px) {
+  .nodes-col--latitude,
+  .nodes-col--longitude,
+  .nodes-col--last-position {
+    display: none;
+  }
+}
+
+@media (max-width: 1109px) {
+  .nodes-col--voltage,
+  .nodes-col--air-util-tx,
+  .nodes-col--altitude {
+    display: none;
+  }
+}
+
+@media (max-width: 899px) {
+  .nodes-col--uptime,
+  .nodes-col--frequency,
+  .nodes-col--modem-preset {
+    display: none;
+  }
+}
+
+@media (max-width: 659px) {
+  .nodes-col--battery,
+  .nodes-col--channel-util,
+  .nodes-col--hw-model {
+    display: none;
   }
 }
 

--- a/web/views/index.erb
+++ b/web/views/index.erb
@@ -166,24 +166,24 @@
   <table id="nodes">
     <thead>
       <tr>
-        <th><button type="button" class="sort-button" data-sort-key="node_id" data-sort-label="Node ID">Node ID <span class="sort-indicator" aria-hidden="true"></span></button></th>
-        <th><button type="button" class="sort-button" data-sort-key="short_name" data-sort-label="Short Name">Short <span class="sort-indicator" aria-hidden="true"></span></button></th>
-        <th><button type="button" class="sort-button" data-sort-key="long_name" data-sort-label="Long Name">Long Name <span class="sort-indicator" aria-hidden="true"></span></button></th>
-        <th><button type="button" class="sort-button" data-sort-key="last_heard" data-sort-label="Last Seen">Last Seen <span class="sort-indicator" aria-hidden="true"></span></button></th>
-        <th><button type="button" class="sort-button" data-sort-key="role" data-sort-label="Role">Role <span class="sort-indicator" aria-hidden="true"></span></button></th>
-        <th><button type="button" class="sort-button" data-sort-key="hw_model" data-sort-label="Hardware Model">HW Model <span class="sort-indicator" aria-hidden="true"></span></button></th>
-        <th><button type="button" class="sort-button" data-sort-key="battery_level" data-sort-label="Battery Level">Battery <span class="sort-indicator" aria-hidden="true"></span></button></th>
-        <th><button type="button" class="sort-button" data-sort-key="voltage" data-sort-label="Voltage">Voltage <span class="sort-indicator" aria-hidden="true"></span></button></th>
-        <th><button type="button" class="sort-button" data-sort-key="uptime_seconds" data-sort-label="Uptime">Uptime <span class="sort-indicator" aria-hidden="true"></span></button></th>
-        <th><button type="button" class="sort-button" data-sort-key="channel_utilization" data-sort-label="Channel Utilization">Channel Util <span class="sort-indicator" aria-hidden="true"></span></button></th>
-        <th><button type="button" class="sort-button" data-sort-key="air_util_tx" data-sort-label="Air Utilization (Tx)">Air Util Tx <span class="sort-indicator" aria-hidden="true"></span></button></th>
-        <th><button type="button" class="sort-button" data-sort-key="temperature" data-sort-label="Temperature">Temperature <span class="sort-indicator" aria-hidden="true"></span></button></th>
-        <th><button type="button" class="sort-button" data-sort-key="relative_humidity" data-sort-label="Humidity">Humidity <span class="sort-indicator" aria-hidden="true"></span></button></th>
-        <th><button type="button" class="sort-button" data-sort-key="barometric_pressure" data-sort-label="Barometric Pressure">Pressure <span class="sort-indicator" aria-hidden="true"></span></button></th>
-        <th><button type="button" class="sort-button" data-sort-key="latitude" data-sort-label="Latitude">Latitude <span class="sort-indicator" aria-hidden="true"></span></button></th>
-        <th><button type="button" class="sort-button" data-sort-key="longitude" data-sort-label="Longitude">Longitude <span class="sort-indicator" aria-hidden="true"></span></button></th>
-        <th><button type="button" class="sort-button" data-sort-key="altitude" data-sort-label="Altitude">Altitude <span class="sort-indicator" aria-hidden="true"></span></button></th>
-        <th><button type="button" class="sort-button" data-sort-key="position_time" data-sort-label="Last Position">Last Position <span class="sort-indicator" aria-hidden="true"></span></button></th>
+        <th class="nodes-col nodes-col--node-id"><button type="button" class="sort-button" data-sort-key="node_id" data-sort-label="Node ID">Node ID <span class="sort-indicator" aria-hidden="true"></span></button></th>
+        <th class="nodes-col nodes-col--short-name"><button type="button" class="sort-button" data-sort-key="short_name" data-sort-label="Short Name">Short <span class="sort-indicator" aria-hidden="true"></span></button></th>
+        <th class="nodes-col nodes-col--long-name"><button type="button" class="sort-button" data-sort-key="long_name" data-sort-label="Long Name">Long Name <span class="sort-indicator" aria-hidden="true"></span></button></th>
+        <th class="nodes-col nodes-col--last-seen"><button type="button" class="sort-button" data-sort-key="last_heard" data-sort-label="Last Seen">Last Seen <span class="sort-indicator" aria-hidden="true"></span></button></th>
+        <th class="nodes-col nodes-col--role"><button type="button" class="sort-button" data-sort-key="role" data-sort-label="Role">Role <span class="sort-indicator" aria-hidden="true"></span></button></th>
+        <th class="nodes-col nodes-col--hw-model"><button type="button" class="sort-button" data-sort-key="hw_model" data-sort-label="Hardware Model">HW Model <span class="sort-indicator" aria-hidden="true"></span></button></th>
+        <th class="nodes-col nodes-col--battery"><button type="button" class="sort-button" data-sort-key="battery_level" data-sort-label="Battery Level">Battery <span class="sort-indicator" aria-hidden="true"></span></button></th>
+        <th class="nodes-col nodes-col--voltage"><button type="button" class="sort-button" data-sort-key="voltage" data-sort-label="Voltage">Voltage <span class="sort-indicator" aria-hidden="true"></span></button></th>
+        <th class="nodes-col nodes-col--uptime"><button type="button" class="sort-button" data-sort-key="uptime_seconds" data-sort-label="Uptime">Uptime <span class="sort-indicator" aria-hidden="true"></span></button></th>
+        <th class="nodes-col nodes-col--channel-util"><button type="button" class="sort-button" data-sort-key="channel_utilization" data-sort-label="Channel Utilization">Channel Util <span class="sort-indicator" aria-hidden="true"></span></button></th>
+        <th class="nodes-col nodes-col--air-util-tx"><button type="button" class="sort-button" data-sort-key="air_util_tx" data-sort-label="Air Utilization (Tx)">Air Util Tx <span class="sort-indicator" aria-hidden="true"></span></button></th>
+        <th class="nodes-col nodes-col--temperature"><button type="button" class="sort-button" data-sort-key="temperature" data-sort-label="Temperature">Temperature <span class="sort-indicator" aria-hidden="true"></span></button></th>
+        <th class="nodes-col nodes-col--humidity"><button type="button" class="sort-button" data-sort-key="relative_humidity" data-sort-label="Humidity">Humidity <span class="sort-indicator" aria-hidden="true"></span></button></th>
+        <th class="nodes-col nodes-col--pressure"><button type="button" class="sort-button" data-sort-key="barometric_pressure" data-sort-label="Barometric Pressure">Pressure <span class="sort-indicator" aria-hidden="true"></span></button></th>
+        <th class="nodes-col nodes-col--latitude"><button type="button" class="sort-button" data-sort-key="latitude" data-sort-label="Latitude">Latitude <span class="sort-indicator" aria-hidden="true"></span></button></th>
+        <th class="nodes-col nodes-col--longitude"><button type="button" class="sort-button" data-sort-key="longitude" data-sort-label="Longitude">Longitude <span class="sort-indicator" aria-hidden="true"></span></button></th>
+        <th class="nodes-col nodes-col--altitude"><button type="button" class="sort-button" data-sort-key="altitude" data-sort-label="Altitude">Altitude <span class="sort-indicator" aria-hidden="true"></span></button></th>
+        <th class="nodes-col nodes-col--last-position"><button type="button" class="sort-button" data-sort-key="position_time" data-sort-label="Last Position">Last Position <span class="sort-indicator" aria-hidden="true"></span></button></th>
       </tr>
     </thead>
     <tbody></tbody>


### PR DESCRIPTION
## Summary
- tag node table headers and cells with semantic column classes
- update responsive styles to match the required viewport breakpoints for column visibility

## Testing
- pytest
- bundle exec rspec
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ee3fc538c8832bb73ea6d7af4640ee