### PR TITLE
Bump fallback version string to v0.5.1

### DIFF
--- a/web/lib/potato_mesh/config.rb
+++ b/web/lib/potato_mesh/config.rb
@@ -129,7 +129,7 @@ module PotatoMesh
     #
     # @return [String] semantic version identifier.
     def version_fallback
-      "v0.5.0"
+      "v0.5.1"
     end
 
     # Default refresh interval for frontend polling routines.


### PR DESCRIPTION
## Summary
- update the PotatoMesh configuration fallback version to v0.5.1 so the UI reports the latest release when git metadata is unavailable

## Testing
- rufo .
- black .
- pytest
- bundle exec rspec
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ee7e07b154832ba536b204d1022e62