### PR TITLE
Display message frequency and channel in chat log

### DIFF
--- a/web/public/assets/js/app/__tests__/chat-format.test.js
+++ b/web/public/assets/js/app/__tests__/chat-format.test.js
@@ -15,9 +15,21 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { extractChatMessageMetadata, formatChatMessagePrefix, formatNodeAnnouncementPrefix, __test__ } from '../chat-format.js';
+import {
+  extractChatMessageMetadata,
+  formatChatMessagePrefix,
+  formatChatChannelTag,
+  formatNodeAnnouncementPrefix,
+  __test__
+} from '../chat-format.js';
 
-const { firstNonNull, normalizeString, normalizeFrequency, normalizeFrequencySlot, FREQUENCY_PLACEHOLDER } = __test__;
+const {
+  firstNonNull,
+  normalizeString,
+  normalizeFrequency,
+  normalizeFrequencySlot,
+  FREQUENCY_PLACEHOLDER
+} = __test__;
 
 test('extractChatMessageMetadata prefers explicit region_frequency and channel_name', () => {
   const payload = {
@@ -67,16 +79,31 @@ test('normalizeFrequency handles numeric and string inputs', () => {
 
 test('formatChatMessagePrefix preserves bracket placeholders', () => {
   assert.equal(
-    formatChatMessagePrefix({ timestamp: '11:46:48', frequency: '868', channelName: 'TEST' }),
-    '[11:46:48][868][TEST]'
+    formatChatMessagePrefix({ timestamp: '11:46:48', frequency: '868' }),
+    '[11:46:48][868]'
   );
   assert.equal(
-    formatChatMessagePrefix({ timestamp: '16:19:19', frequency: null, channelName: 'MediumFast' }),
-    `[16:19:19][${FREQUENCY_PLACEHOLDER}][MediumFast]`
+    formatChatMessagePrefix({ timestamp: '16:19:19', frequency: null }),
+    `[16:19:19][${FREQUENCY_PLACEHOLDER}]`
   );
   assert.equal(
-    formatChatMessagePrefix({ timestamp: '09:00:00', frequency: '', channelName: '' }),
-    `[09:00:00][${FREQUENCY_PLACEHOLDER}][]`
+    formatChatMessagePrefix({ timestamp: '09:00:00', frequency: '' }),
+    `[09:00:00][${FREQUENCY_PLACEHOLDER}]`
+  );
+});
+
+test('formatChatChannelTag wraps channel names after the short name slot', () => {
+  assert.equal(
+    formatChatChannelTag({ channelName: 'TEST' }),
+    '[TEST]'
+  );
+  assert.equal(
+    formatChatChannelTag({ channelName: '' }),
+    '[]'
+  );
+  assert.equal(
+    formatChatChannelTag({ channelName: null }),
+    '[]'
   );
 });
 

--- a/web/public/assets/js/app/chat-format.js
+++ b/web/public/assets/js/app/chat-format.js
@@ -46,22 +46,35 @@ export function extractChatMessageMetadata(message) {
 /**
  * Produce the formatted prefix for a chat message entry.
  *
- * Timestamp, frequency, and channel name will each be wrapped in square
- * brackets. Missing metadata values result in empty brackets to preserve the
- * positional layout expected by operators.
+ * Timestamp and frequency will each be wrapped in square brackets. Missing
+ * metadata values result in empty brackets (with the frequency replaced by the
+ * configured placeholder) to preserve the positional layout expected by
+ * operators.
  *
  * @param {{
  *   timestamp: string,
- *   frequency: string|null,
- *   channelName: string|null
+ *   frequency: string|null
  * }} params Normalised and escaped display strings.
  * @returns {string} Prefix string suitable for HTML insertion.
  */
-export function formatChatMessagePrefix({ timestamp, frequency, channelName }) {
+export function formatChatMessagePrefix({ timestamp, frequency }) {
   const ts = typeof timestamp === 'string' ? timestamp : '';
   const freq = normalizeFrequencySlot(frequency);
+  return `[${ts}][${freq}]`;
+}
+
+/**
+ * Render the channel tag that follows the short name in a chat message entry.
+ *
+ * Empty channel names remain blank within the brackets, mirroring the original
+ * UI behaviour that reserves the slot without introducing placeholder text.
+ *
+ * @param {{ channelName: string|null }} params Normalised and escaped display strings.
+ * @returns {string} Channel tag suitable for HTML insertion.
+ */
+export function formatChatChannelTag({ channelName }) {
   const channel = typeof channelName === 'string' ? channelName : channelName == null ? '' : String(channelName);
-  return `[${ts}][${freq}][${channel}]`;
+  return `[${channel}]`;
 }
 
 /**
@@ -176,5 +189,6 @@ export const __test__ = {
   formatChatMessagePrefix,
   formatNodeAnnouncementPrefix,
   normalizeFrequencySlot,
-  FREQUENCY_PLACEHOLDER
+  FREQUENCY_PLACEHOLDER,
+  formatChatChannelTag
 };

--- a/web/public/assets/js/app/main.js
+++ b/web/public/assets/js/app/main.js
@@ -19,7 +19,12 @@ import { createMapAutoFitController } from './map-auto-fit-controller.js';
 import { attachNodeInfoRefreshToMarker, overlayToPopupNode } from './map-marker-node-info.js';
 import { createShortInfoOverlayStack } from './short-info-overlay-manager.js';
 import { refreshNodeInformation } from './node-details.js';
-import { extractChatMessageMetadata, formatChatMessagePrefix, formatNodeAnnouncementPrefix } from './chat-format.js';
+import {
+  extractChatMessageMetadata,
+  formatChatMessagePrefix,
+  formatChatChannelTag,
+  formatNodeAnnouncementPrefix
+} from './chat-format.js';
 
 /**
  * Entry point for the interactive dashboard. Wires up event listeners,
@@ -2093,11 +2098,13 @@ export function initializeApp(config) {
     const metadata = extractChatMessageMetadata(m);
     const prefix = formatChatMessagePrefix({
       timestamp: escapeHtml(ts),
-      frequency: metadata.frequency ? escapeHtml(metadata.frequency) : '',
+      frequency: metadata.frequency ? escapeHtml(metadata.frequency) : ''
+    });
+    const channelTag = formatChatChannelTag({
       channelName: metadata.channelName ? escapeHtml(metadata.channelName) : ''
     });
     div.className = 'chat-entry-msg';
-    div.innerHTML = `${prefix} ${short} ${text}`;
+    div.innerHTML = `${prefix} ${short} ${channelTag} ${text}`;
     return div;
   }
 


### PR DESCRIPTION
## Summary
- add a dedicated chat formatting helper to normalize frequency and channel metadata from message payloads
- render chat message prefixes with timestamp, frequency, and channel name using the shared helper
- add unit coverage for the chat metadata helper to keep message formatting behaviour exercised
- fix #124 

## Testing
- black .
- rufo .
- pytest
- bundle exec rspec
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ee7dd93dc8832bb26da468726b1d0d