### PR TITLE
Ensure Docker deployments persist keyfile and well-known assets

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -50,9 +50,15 @@ Additional environment variables are optional:
 Use the `docker-compose.yml` file provided in the repository (or download the
 [raw file from GitHub](https://raw.githubusercontent.com/l5yth/potato-mesh/main/docker-compose.yml)).
 It already references the published GHCR images, defines persistent volumes for
-data and logs, and includes optional bridge-profile services for environments
-that require classic port mapping. Place this file in the same directory as
-your `.env` file so Compose can pick up both.
+data, configuration, and logs, and includes optional bridge-profile services for
+environments that require classic port mapping. Place this file in the same
+directory as your `.env` file so Compose can pick up both.
+
+The dedicated configuration volume binds to `/app/.config/potato-mesh` inside
+the container. This path stores the instance private key and staged
+`/.well-known/potato-mesh` documents. Because the volume persists independently
+of container lifecycle events, generated credentials are not replaced on reboot
+or re-deploy.
 
 ## Start the stack
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ The migrated key is written to `<XDG_CONFIG_HOME>/potato-mesh/keyfile` and the
 well-known document is staged in
 `<XDG_CONFIG_HOME>/potato-mesh/well-known/potato-mesh`.
 
+When deploying with Docker Compose, the default `docker-compose.yml` mounts a
+named volume at `/app/.config/potato-mesh` to persist these files. Avoid
+removing this volume once a key has been generated so the instance identity and
+well-known metadata remain stable across restarts.
+
 The web app can be configured with environment variables (defaults shown):
 
 * `SITE_NAME` - title and header shown in the UI (default: "PotatoMesh Demo")

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,6 +6,7 @@ services:
     volumes:
       - ./web:/app
       - ./data:/app/.local/share/potato-mesh
+      - ./.config/potato-mesh:/app/.config/potato-mesh
       - /app/vendor/bundle
 
   web-bridge:
@@ -14,6 +15,7 @@ services:
     volumes:
       - ./web:/app
       - ./data:/app/.local/share/potato-mesh
+      - ./.config/potato-mesh:/app/.config/potato-mesh
       - /app/vendor/bundle
     ports:
       - "41447:41447"
@@ -25,6 +27,7 @@ services:
     volumes:
       - ./data:/app
       - ./data:/app/.local/share/potato-mesh
+      - ./.config/potato-mesh:/app/.config/potato-mesh
       - /app/.local
 
   ingestor-bridge:
@@ -33,4 +36,5 @@ services:
     volumes:
       - ./data:/app
       - ./data:/app/.local/share/potato-mesh
+      - ./.config/potato-mesh:/app/.config/potato-mesh
       - /app/.local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ x-web-base: &web-base
   command: ["ruby", "app.rb", "-p", "41447", "-o", "0.0.0.0"]
   volumes:
     - potatomesh_data:/app/.local/share/potato-mesh
+    - potatomesh_config:/app/.config/potato-mesh
     - potatomesh_logs:/app/logs
   restart: unless-stopped
   deploy:
@@ -35,6 +36,7 @@ x-ingestor-base: &ingestor-base
     DEBUG: ${DEBUG:-0}
   volumes:
     - potatomesh_data:/app/.local/share/potato-mesh
+    - potatomesh_config:/app/.config/potato-mesh
     - potatomesh_logs:/app/logs
   devices:
     - ${CONNECTION:-/dev/ttyACM0}:${CONNECTION:-/dev/ttyACM0}
@@ -84,6 +86,8 @@ services:
 
 volumes:
   potatomesh_data:
+    driver: local
+  potatomesh_config:
     driver: local
   potatomesh_logs:
     driver: local


### PR DESCRIPTION
## Summary
- mount a dedicated configuration volume in docker-compose to persist the XDG config directory
- wire the same persistence into the development compose overrides
- document the new configuration volume so operators keep generated keys and .well-known data
- fix #341 

## Testing
- `rufo .`
- `black .`
- `pytest`
- `bundle exec rspec`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68efa92fea68832b998879eef302607b