### PR TITLE
Remove federation timeout environment overrides

### DIFF
--- a/web/lib/potato_mesh/application/federation.rb
+++ b/web/lib/potato_mesh/application/federation.rb
@@ -358,7 +358,7 @@ module PotatoMesh
       def build_remote_http_client(uri)
         http = Net::HTTP.new(uri.host, uri.port)
         http.open_timeout = PotatoMesh::Config.remote_instance_http_timeout
-        http.read_timeout = PotatoMesh::Config.remote_instance_http_timeout
+        http.read_timeout = PotatoMesh::Config.remote_instance_read_timeout
         http.use_ssl = uri.scheme == "https"
         return http unless http.use_ssl?
 

--- a/web/lib/potato_mesh/config.rb
+++ b/web/lib/potato_mesh/config.rb
@@ -32,6 +32,8 @@ module PotatoMesh
     DEFAULT_FREQUENCY = "915MHz"
     DEFAULT_CONTACT_LINK = "#potatomesh:dod.ngo"
     DEFAULT_MAX_DISTANCE_KM = 42.0
+    DEFAULT_REMOTE_INSTANCE_CONNECT_TIMEOUT = 5
+    DEFAULT_REMOTE_INSTANCE_READ_TIMEOUT = 12
 
     # Resolve the absolute path to the web application root directory.
     #
@@ -269,11 +271,18 @@ module PotatoMesh
       "rsa-sha256"
     end
 
-    # Timeout used when querying remote instances during federation.
+    # Connection timeout used when establishing federation HTTP sockets.
     #
-    # @return [Integer] HTTP timeout in seconds.
+    # @return [Integer] connect timeout in seconds.
     def remote_instance_http_timeout
-      5
+      DEFAULT_REMOTE_INSTANCE_CONNECT_TIMEOUT
+    end
+
+    # Read timeout used when streaming federation HTTP responses.
+    #
+    # @return [Integer] read timeout in seconds.
+    def remote_instance_read_timeout
+      DEFAULT_REMOTE_INSTANCE_READ_TIMEOUT
     end
 
     # Maximum acceptable age for remote node data.

--- a/web/spec/config_spec.rb
+++ b/web/spec/config_spec.rb
@@ -137,6 +137,38 @@ RSpec.describe PotatoMesh::Config do
     end
   end
 
+  describe ".remote_instance_http_timeout" do
+    it "returns the baked-in connect timeout" do
+      expect(described_class.remote_instance_http_timeout).to eq(
+        PotatoMesh::Config::DEFAULT_REMOTE_INSTANCE_CONNECT_TIMEOUT,
+      )
+    end
+
+    it "ignores environment overrides" do
+      within_env("REMOTE_INSTANCE_CONNECT_TIMEOUT" => "27") do
+        expect(described_class.remote_instance_http_timeout).to eq(
+          PotatoMesh::Config::DEFAULT_REMOTE_INSTANCE_CONNECT_TIMEOUT,
+        )
+      end
+    end
+  end
+
+  describe ".remote_instance_read_timeout" do
+    it "returns the baked-in read timeout" do
+      expect(described_class.remote_instance_read_timeout).to eq(
+        PotatoMesh::Config::DEFAULT_REMOTE_INSTANCE_READ_TIMEOUT,
+      )
+    end
+
+    it "ignores environment overrides" do
+      within_env("REMOTE_INSTANCE_READ_TIMEOUT" => "20") do
+        expect(described_class.remote_instance_read_timeout).to eq(
+          PotatoMesh::Config::DEFAULT_REMOTE_INSTANCE_READ_TIMEOUT,
+        )
+      end
+    end
+  end
+
   describe ".db_path" do
     it "returns the default path inside the data directory" do
       expect(described_class.db_path).to eq(described_class.default_db_path)

--- a/web/spec/federation_spec.rb
+++ b/web/spec/federation_spec.rb
@@ -113,10 +113,12 @@ RSpec.describe PotatoMesh::App::Federation do
   end
 
   describe ".build_remote_http_client" do
-    let(:timeout) { 15 }
+    let(:connect_timeout) { 5 }
+    let(:read_timeout) { 12 }
 
     before do
-      allow(PotatoMesh::Config).to receive(:remote_instance_http_timeout).and_return(timeout)
+      allow(PotatoMesh::Config).to receive(:remote_instance_http_timeout).and_return(connect_timeout)
+      allow(PotatoMesh::Config).to receive(:remote_instance_read_timeout).and_return(read_timeout)
     end
 
     it "configures SSL settings for HTTPS endpoints" do
@@ -129,8 +131,8 @@ RSpec.describe PotatoMesh::App::Federation do
       http = federation_helpers.build_remote_http_client(uri)
 
       expect(http.use_ssl?).to be(true)
-      expect(http.open_timeout).to eq(timeout)
-      expect(http.read_timeout).to eq(timeout)
+      expect(http.open_timeout).to eq(connect_timeout)
+      expect(http.read_timeout).to eq(read_timeout)
       expect(http.cert_store).to eq(store)
       expect(http.verify_mode).to eq(OpenSSL::SSL::VERIFY_PEER)
       expect(http.verify_callback).to eq(callback)
@@ -146,8 +148,8 @@ RSpec.describe PotatoMesh::App::Federation do
 
       expect(http.use_ssl?).to be(false)
       expect(http.cert_store).to be_nil
-      expect(http.open_timeout).to eq(timeout)
-      expect(http.read_timeout).to eq(timeout)
+      expect(http.open_timeout).to eq(connect_timeout)
+      expect(http.read_timeout).to eq(read_timeout)
     end
 
     it "leaves the certificate store unset when unavailable" do


### PR DESCRIPTION
## Summary
- keep the federation connect and read timeouts as fixed configuration defaults
- update the configuration specs to assert the constants and ignore environment overrides
- remove timeout environment variable documentation now that the values are not configurable

## Testing
- rufo .
- black .
- bundle exec rspec
- pytest
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68efd6a25d44832b81d4754a7b179dff