### PR TITLE
Ensure INSTANCE_DOMAIN propagates to containers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,11 @@ CONTACT_LINK='#potatomesh:dod.ngo'
 # Debug mode (0=off, 1=on)
 DEBUG=0
 
+# Public domain name for this PotatoMesh instance
+# Provide a hostname (with optional port) that resolves to the web service.
+# Example: mesh.example.org or mesh.example.org:41447
+INSTANCE_DOMAIN=mesh.example.org
+
 # Docker image architecture (linux-amd64, linux-arm64, linux-armv7)
 POTATOMESH_IMAGE_ARCH=linux-amd64
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -31,6 +31,7 @@ against the web API.
 API_TOKEN=replace-with-a-strong-token
 SITE_NAME=PotatoMesh Demo
 CONNECTION=/dev/ttyACM0
+INSTANCE_DOMAIN=mesh.example.org
 ```
 
 Additional environment variables are optional:
@@ -43,6 +44,8 @@ Additional environment variables are optional:
   the ingestor.
 - `CHANNEL_INDEX` selects the LoRa channel when using serial or Bluetooth
   connections.
+- `INSTANCE_DOMAIN` pins the public hostname advertised by the web UI and API
+  responses, bypassing reverse DNS detection when set.
 - `DEBUG` enables verbose logging across the stack.
 
 ## Docker Compose file

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ The web app can be configured with environment variables (defaults shown):
 * `MAX_DISTANCE` - hide nodes farther than this distance from the center (default: `42`)
 * `CONTACT_LINK` - chat link or Matrix alias for footer and overlay (default: `#potatomesh:dod.ngo`)
 * `PRIVATE` - set to `1` to hide the chat UI, disable message APIs, and exclude hidden clients (default: unset)
+* `INSTANCE_DOMAIN` - public hostname (optionally with port) used for metadata, federation, and API links (default: auto-detected)
 
 The application derives SEO-friendly document titles, descriptions, and social
 preview tags from these existing configuration values and reuses the bundled

--- a/configure.sh
+++ b/configure.sh
@@ -75,6 +75,7 @@ MAX_DISTANCE=$(grep "^MAX_DISTANCE=" .env 2>/dev/null | cut -d'=' -f2- | tr -d '
 CONTACT_LINK=$(grep "^CONTACT_LINK=" .env 2>/dev/null | cut -d'=' -f2- | tr -d '"' || echo "#potatomesh:dod.ngo")
 API_TOKEN=$(grep "^API_TOKEN=" .env 2>/dev/null | cut -d'=' -f2- | tr -d '"' || echo "")
 POTATOMESH_IMAGE_ARCH=$(grep "^POTATOMESH_IMAGE_ARCH=" .env 2>/dev/null | cut -d'=' -f2- | tr -d '"' || echo "linux-amd64")
+INSTANCE_DOMAIN=$(grep "^INSTANCE_DOMAIN=" .env 2>/dev/null | cut -d'=' -f2- | tr -d '"' || echo "")
 
 echo "📍 Location Settings"
 echo "-------------------"
@@ -98,6 +99,13 @@ echo "🛠 Docker Settings"
 echo "------------------"
 echo "Specify the Docker image architecture for your host (linux-amd64, linux-arm64, linux-armv7)."
 read_with_default "Docker image architecture" "$POTATOMESH_IMAGE_ARCH" POTATOMESH_IMAGE_ARCH
+
+echo ""
+echo "🌐 Domain Settings"
+echo "------------------"
+echo "Provide the public hostname that clients should use to reach this PotatoMesh instance."
+echo "Leave blank to allow automatic detection via reverse DNS."
+read_with_default "Instance domain (e.g. mesh.example.org)" "$INSTANCE_DOMAIN" INSTANCE_DOMAIN
 
 echo ""
 echo "🔐 Security Settings"
@@ -142,6 +150,11 @@ update_env "MAX_DISTANCE" "$MAX_DISTANCE"
 update_env "CONTACT_LINK" "\"$CONTACT_LINK\""
 update_env "API_TOKEN" "$API_TOKEN"
 update_env "POTATOMESH_IMAGE_ARCH" "$POTATOMESH_IMAGE_ARCH"
+if [ -n "$INSTANCE_DOMAIN" ]; then
+    update_env "INSTANCE_DOMAIN" "$INSTANCE_DOMAIN"
+else
+    sed -i.bak '/^INSTANCE_DOMAIN=.*/d' .env
+fi
 
 # Migrate legacy connection settings and ensure defaults exist
 if grep -q "^MESH_SERIAL=" .env; then
@@ -176,6 +189,7 @@ echo "   Frequency: $FREQUENCY"
 echo "   Chat: ${CONTACT_LINK:-'Not set'}"
 echo "   API Token: ${API_TOKEN:0:8}..."
 echo "   Docker Image Arch: $POTATOMESH_IMAGE_ARCH"
+echo "   Instance Domain: ${INSTANCE_DOMAIN:-'Auto-detected'}"
 echo ""
 echo "🚀 You can now start PotatoMesh with:"
 echo "   docker-compose up -d"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ x-web-base: &web-base
     MAX_DISTANCE: ${MAX_DISTANCE:-42}
     CONTACT_LINK: ${CONTACT_LINK:-#potatomesh:dod.ngo}
     API_TOKEN: ${API_TOKEN}
+    INSTANCE_DOMAIN: ${INSTANCE_DOMAIN}
     DEBUG: ${DEBUG:-0}
   command: ["ruby", "app.rb", "-p", "41447", "-o", "0.0.0.0"]
   volumes:
@@ -33,6 +34,7 @@ x-ingestor-base: &ingestor-base
     CHANNEL_INDEX: ${CHANNEL_INDEX:-0}
     POTATOMESH_INSTANCE: ${POTATOMESH_INSTANCE:-http://web:41447}
     API_TOKEN: ${API_TOKEN}
+    INSTANCE_DOMAIN: ${INSTANCE_DOMAIN}
     DEBUG: ${DEBUG:-0}
   volumes:
     - potatomesh_data:/app/.local/share/potato-mesh


### PR DESCRIPTION
## Summary
- add INSTANCE_DOMAIN to the shared docker-compose environments so the web and ingestor containers receive the value from .env
- extend the configuration script and environment template to support setting INSTANCE_DOMAIN explicitly
- document the new environment setting in the Docker guide and README for Compose deployments
- fix #357 

## Testing
- rufo .
- black .
- pytest
- bundle exec rspec
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f00e846a68832b9deff6771626e86c