### PR TITLE
Harden instance domain validation

### DIFF
--- a/web/lib/potato_mesh/application/networking.rb
+++ b/web/lib/potato_mesh/application/networking.rb
@@ -62,6 +62,22 @@ module PotatoMesh
           candidate = "#{candidate_host}:#{port}" if port_required?(uri, trimmed)
         end
 
+        ipv6_with_port = candidate.match(/\A(?<address>.+):(?<port>\d+)\z/)
+        if ipv6_with_port
+          address = ipv6_with_port[:address]
+          port = ipv6_with_port[:port]
+          literal = ipv6_literal?(address)
+          if literal && PotatoMesh::Sanitizer.valid_port?(port)
+            candidate = "[#{literal}]:#{port}"
+          else
+            ipv6_literal = ipv6_literal?(candidate)
+            candidate = "[#{ipv6_literal}]" if ipv6_literal
+          end
+        else
+          ipv6_literal = ipv6_literal?(candidate)
+          candidate = "[#{ipv6_literal}]" if ipv6_literal
+        end
+
         sanitized = sanitize_instance_domain(candidate)
         unless sanitized
           raise "INSTANCE_DOMAIN must be a bare hostname (optionally with a port) without schemes or paths: #{raw.inspect}"

--- a/web/spec/sanitizer_spec.rb
+++ b/web/spec/sanitizer_spec.rb
@@ -30,17 +30,24 @@ RSpec.describe PotatoMesh::Sanitizer do
     it "rejects invalid domains" do
       expect(described_class.sanitize_instance_domain(nil)).to be_nil
       expect(described_class.sanitize_instance_domain(" ")).to be_nil
+      expect(described_class.sanitize_instance_domain("example")).to be_nil
       expect(described_class.sanitize_instance_domain("example.org/")).to be_nil
       expect(described_class.sanitize_instance_domain("example .org")).to be_nil
+      expect(described_class.sanitize_instance_domain("mesh_instance.example")).to be_nil
+      expect(described_class.sanitize_instance_domain("example.org:70000")).to be_nil
+      expect(described_class.sanitize_instance_domain("[::1")).to be_nil
     end
 
     it "normalises valid domains" do
       expect(described_class.sanitize_instance_domain(" Example.Org. ")).to eq("example.org")
-      expect(described_class.sanitize_instance_domain("[::1]")).to eq("[::1]")
+      expect(described_class.sanitize_instance_domain("Example.Org:443")).to eq("example.org:443")
+      expect(described_class.sanitize_instance_domain("[2001:DB8::1]")).to eq("[2001:db8::1]")
+      expect(described_class.sanitize_instance_domain("127.0.0.1:8080")).to eq("127.0.0.1:8080")
     end
 
     it "preserves case when requested" do
       expect(described_class.sanitize_instance_domain("Mesh.Example", downcase: false)).to eq("Mesh.Example")
+      expect(described_class.sanitize_instance_domain("[2001:DB8::1]", downcase: false)).to eq("[2001:DB8::1]")
     end
   end
 


### PR DESCRIPTION
## Summary
- tighten instance domain sanitization to enforce RFC-style hostnames, IPv4 literals, and bracketed IPv6 literals (with optional ports)
- ensure the ingest route rejects registrations whose domains fail the stricter validator and log the reason
- normalize configured instance domains containing IPv6 literals before validation and add comprehensive specs for the new rules

## Testing
- rufo .
- black .
- bundle exec rspec
- pytest
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68f00cbc9880832b88a2ba365ca31ab6