### PR TITLE
Decouple message API node hydration

### DIFF
--- a/web/public/assets/js/app/__tests__/message-node-hydrator.test.js
+++ b/web/public/assets/js/app/__tests__/message-node-hydrator.test.js
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2025 l5yth
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createMessageNodeHydrator } from '../message-node-hydrator.js';
+
+/**
+ * Capture warning invocations produced during a test run.
+ */
+class LoggerStub {
+  constructor() {
+    this.messages = [];
+  }
+
+  /**
+   * Record a warning message for later inspection.
+   *
+   * @param {...*} args Warning arguments.
+   * @returns {void}
+   */
+  warn(...args) {
+    this.messages.push(args);
+  }
+}
+
+test('hydrate attaches cached nodes without performing lookups', async () => {
+  const node = { node_id: '!abc', short_name: 'Node' };
+  const nodesById = new Map([[node.node_id, node]]);
+  const hydrator = createMessageNodeHydrator({
+    fetchNodeById: async () => {
+      throw new Error('fetch should not be called');
+    },
+    applyNodeFallback: () => {}
+  });
+
+  const messages = [{ node_id: '!abc', text: 'Hello' }];
+  const result = await hydrator.hydrate(messages, nodesById);
+
+  assert.equal(result.length, 1);
+  assert.strictEqual(result[0].node, node);
+  assert.equal(nodesById.size, 1);
+});
+
+test('hydrate fetches missing nodes once and caches the result', async () => {
+  let fetchCalls = 0;
+  const fetchedNode = { node_id: '!fetch', short_name: 'Fetched' };
+  const hydrator = createMessageNodeHydrator({
+    fetchNodeById: async id => {
+      fetchCalls += 1;
+      assert.equal(id, '!fetch');
+      return { ...fetchedNode };
+    },
+    applyNodeFallback: () => {}
+  });
+  const nodesById = new Map();
+  const messages = [{ from_id: '!fetch', text: 'one' }, { node_id: '!fetch', text: 'two' }];
+
+  const result = await hydrator.hydrate(messages, nodesById);
+
+  assert.equal(fetchCalls, 1);
+  assert.strictEqual(nodesById.get('!fetch').short_name, 'Fetched');
+  assert.strictEqual(result[0].node, nodesById.get('!fetch'));
+  assert.strictEqual(result[1].node, nodesById.get('!fetch'));
+});
+
+test('hydrate falls back to placeholders when lookups fail', async () => {
+  const logger = new LoggerStub();
+  let fallbackCalls = 0;
+  const hydrator = createMessageNodeHydrator({
+    fetchNodeById: async () => null,
+    applyNodeFallback: node => {
+      fallbackCalls += 1;
+      if (!node.short_name) {
+        node.short_name = 'Fallback';
+      }
+    },
+    logger
+  });
+  const nodesById = new Map();
+  const messages = [{ from_id: '!missing', text: 'hi' }];
+
+  const result = await hydrator.hydrate(messages, nodesById);
+
+  assert.equal(nodesById.has('!missing'), false);
+  assert.equal(fallbackCalls, 1);
+  assert.ok(result[0].node);
+  assert.equal(result[0].node.short_name, 'Fallback');
+  assert.equal(logger.messages.length, 0);
+});
+
+test('hydrate records warning when fetch rejects', async () => {
+  const logger = new LoggerStub();
+  const hydrator = createMessageNodeHydrator({
+    fetchNodeById: async () => {
+      throw new Error('network error');
+    },
+    applyNodeFallback: () => {},
+    logger
+  });
+  const nodesById = new Map();
+  const messages = [{ from_id: '!warn', text: 'warn' }];
+
+  const result = await hydrator.hydrate(messages, nodesById);
+
+  assert.equal(result[0].node.node_id, '!warn');
+  assert.ok(logger.messages.length >= 1);
+  assert.equal(nodesById.has('!warn'), false);
+});

--- a/web/public/assets/js/app/message-node-hydrator.js
+++ b/web/public/assets/js/app/message-node-hydrator.js
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2025 l5yth
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Build a hydrator capable of attaching node metadata to chat messages.
+ *
+ * @param {{
+ *   fetchNodeById: (nodeId: string) => Promise<object|null>,
+ *   applyNodeFallback: (node: object) => void,
+ *   logger?: { warn?: (message?: any, ...optionalParams: any[]) => void }
+ * }} options Factory configuration.
+ * @returns {{
+ *   hydrate: (messages: Array<object>|null|undefined, nodesById: Map<string, object>) => Promise<Array<object>>
+ * }} Hydrator API.
+ */
+export function createMessageNodeHydrator({ fetchNodeById, applyNodeFallback, logger = console }) {
+  if (typeof fetchNodeById !== 'function') {
+    throw new TypeError('fetchNodeById must be a function');
+  }
+  if (typeof applyNodeFallback !== 'function') {
+    throw new TypeError('applyNodeFallback must be a function');
+  }
+
+  /** @type {Map<string, Promise<object|null>>} */
+  const inflightLookups = new Map();
+
+  /**
+   * Normalise potential node identifiers into canonical strings.
+   *
+   * @param {*} value Raw node identifier value.
+   * @returns {string} Trimmed identifier or empty string when invalid.
+   */
+  function normalizeNodeId(value) {
+    if (value == null) return '';
+    const source = typeof value === 'string' ? value : String(value);
+    const trimmed = source.trim();
+    return trimmed.length > 0 ? trimmed : '';
+  }
+
+  /**
+   * Resolve the node metadata for the provided identifier.
+   *
+   * @param {string} nodeId Canonical node identifier.
+   * @param {Map<string, object>} nodesById Existing node cache.
+   * @returns {Promise<object|null>} Resolved node or null when unavailable.
+   */
+  async function resolveNode(nodeId, nodesById) {
+    const id = normalizeNodeId(nodeId);
+    if (!id) return null;
+    if (nodesById instanceof Map && nodesById.has(id)) {
+      return nodesById.get(id);
+    }
+    if (inflightLookups.has(id)) {
+      return inflightLookups.get(id);
+    }
+
+    const promise = Promise.resolve()
+      .then(() => fetchNodeById(id))
+      .then(node => {
+        if (node && typeof node === 'object') {
+          applyNodeFallback(node);
+          if (nodesById instanceof Map) {
+            nodesById.set(id, node);
+          }
+          return node;
+        }
+        return null;
+      })
+      .catch(error => {
+        if (logger && typeof logger.warn === 'function') {
+          logger.warn('message node lookup failed', { nodeId: id, error });
+        }
+        return null;
+      })
+      .finally(() => {
+        inflightLookups.delete(id);
+      });
+
+    inflightLookups.set(id, promise);
+    return promise;
+  }
+
+  /**
+   * Attach node information to the provided message collection.
+   *
+   * @param {Array<object>|null|undefined} messages Message payloads from the API.
+   * @param {Map<string, object>} nodesById Lookup table of known nodes.
+   * @returns {Promise<Array<object>>} Hydrated message entries.
+   */
+  async function hydrate(messages, nodesById) {
+    if (!Array.isArray(messages) || messages.length === 0) {
+      return Array.isArray(messages) ? messages : [];
+    }
+
+    const tasks = [];
+    for (const message of messages) {
+      if (!message || typeof message !== 'object') {
+        continue;
+      }
+
+      const explicitId = normalizeNodeId(message.node_id ?? message.nodeId ?? '');
+      const fallbackId = normalizeNodeId(message.from_id ?? message.fromId ?? '');
+      const targetId = explicitId || fallbackId;
+
+      if (!targetId) {
+        message.node = null;
+        continue;
+      }
+
+      message.node_id = targetId;
+      const existing = nodesById instanceof Map ? nodesById.get(targetId) : null;
+      if (existing) {
+        message.node = existing;
+        continue;
+      }
+
+      const task = resolveNode(targetId, nodesById).then(node => {
+        if (node) {
+          message.node = node;
+        } else {
+          const placeholder = { node_id: targetId };
+          applyNodeFallback(placeholder);
+          message.node = placeholder;
+        }
+      });
+      tasks.push(task);
+    }
+
+    if (tasks.length > 0) {
+      await Promise.all(tasks);
+    }
+
+    return messages;
+  }
+
+  return { hydrate };
+}

--- a/web/spec/app_spec.rb
+++ b/web/spec/app_spec.rb
@@ -3082,7 +3082,7 @@ RSpec.describe "Potato Mesh Sinatra app" do
   end
 
   describe "GET /api/messages" do
-    it "returns the stored messages along with joined node data" do
+    it "returns the stored messages with canonical node references" do
       import_nodes_fixture
       import_messages_fixture
 
@@ -3096,86 +3096,59 @@ RSpec.describe "Potato Mesh Sinatra app" do
         acc[row["id"]] = row
       end
 
-      nodes_by_id = {}
       node_aliases = {}
 
       nodes_fixture.each do |node|
-        node_id = node["node_id"]
-        expected_row = expected_node_row(node)
-        nodes_by_id[node_id] = expected_row
-
         if (num = node["num"])
-          node_aliases[num.to_s] = node_id
+          node_aliases[num.to_s] = node["node_id"]
         end
-      end
-
-      messages_fixture.each do |message|
-        node = message["node"]
-        next unless node.is_a?(Hash)
-
-        canonical = node["node_id"]
-        num = node["num"]
-        next unless canonical && num
-
-        node_aliases[num.to_s] ||= canonical
-      end
-
-      latest_rx_by_node = {}
-      messages_fixture.each do |message|
-        rx_time = message["rx_time"]
-        next unless rx_time
-
-        canonical = nil
-        from_id = message["from_id"]
-
-        if from_id.is_a?(String)
-          trimmed = from_id.strip
-          unless trimmed.empty?
-            if trimmed.match?(/\A[0-9]+\z/)
-              canonical = node_aliases[trimmed] || trimmed
-            else
-              canonical = trimmed
-            end
-          end
-        end
-
-        canonical ||= message.dig("node", "node_id")
-
-        if canonical.nil?
-          num = message.dig("node", "num")
-          canonical = node_aliases[num.to_s] if num
-        end
-
-        next unless canonical
-
-        existing = latest_rx_by_node[canonical]
-        latest_rx_by_node[canonical] = [existing, rx_time].compact.max
       end
 
       messages_fixture.each do |message|
         expected = message.reject { |key, _| key == "node" }
         actual_row = actual_by_id.fetch(message["id"])
 
-        expect(actual_row["rx_time"]).to eq(expected["rx_time"])
-        expect(actual_row["rx_iso"]).to eq(expected["rx_iso"])
-
         expected_from_id = expected["from_id"]
-        if expected_from_id.is_a?(String) && expected_from_id.match?(/\A[0-9]+\z/)
-          expected_from_id = node_aliases[expected_from_id] || expected_from_id
+        if expected_from_id.is_a?(String)
+          trimmed = expected_from_id.strip
+          if trimmed.match?(/\A[0-9]+\z/)
+            expected_from_id = node_aliases[trimmed] || message.dig("node", "node_id") || trimmed
+          else
+            expected_from_id = trimmed
+          end
         elsif expected_from_id.nil?
           expected_from_id = message.dig("node", "node_id")
         end
         expect(actual_row["from_id"]).to eq(expected_from_id)
-        expect(actual_row).not_to have_key("from_node_id")
-        expect(actual_row).not_to have_key("from_node_num")
+
+        expected_node_id = if expected_from_id.is_a?(String)
+            expected_from_id
+          else
+            node_id = message.dig("node", "node_id")
+            if node_id.nil?
+              num = message.dig("node", "num")
+              node_id = node_aliases[num.to_s] if num
+            end
+            node_id
+          end
+
+        if expected_node_id
+          expect(actual_row["node_id"]).to eq(expected_node_id)
+        else
+          expect(actual_row).not_to have_key("node_id")
+        end
 
         expected_to_id = expected["to_id"]
-        if expected_to_id.is_a?(String) && expected_to_id.match?(/\A[0-9]+\z/)
-          expected_to_id = node_aliases[expected_to_id] || expected_to_id
+        if expected_to_id.is_a?(String)
+          trimmed_to = expected_to_id.strip
+          if trimmed_to.match?(/\A[0-9]+\z/)
+            expected_to_id = node_aliases[trimmed_to] || trimmed_to
+          else
+            expected_to_id = trimmed_to
+          end
         end
         expect(actual_row["to_id"]).to eq(expected_to_id)
-        expect(actual_row).not_to have_key("to_node_id")
-        expect(actual_row).not_to have_key("to_node_num")
+
         expect(actual_row["channel"]).to eq(expected["channel"])
         expect(actual_row["portnum"]).to eq(expected["portnum"])
         expect(actual_row["text"]).to eq(expected["text"])
@@ -3186,46 +3159,11 @@ RSpec.describe "Potato Mesh Sinatra app" do
         expect(actual_row["lora_freq"]).to eq(expected["lora_freq"])
         expect(actual_row["modem_preset"]).to eq(expected["modem_preset"])
         expect(actual_row["channel_name"]).to eq(expected["channel_name"])
-
-        if expected["from_id"]
-          lookup_id = expected["from_id"]
-          node_expected = nodes_by_id[lookup_id]
-
-          unless node_expected
-            canonical_id = node_aliases[lookup_id.to_s]
-            expect(canonical_id).not_to be_nil,
-                                        "node fixture missing for from_id #{lookup_id.inspect}"
-            node_expected = nodes_by_id.fetch(canonical_id)
-          end
-
-          node_actual = actual_row.fetch("node")
-
-          expect(node_actual["node_id"]).to eq(node_expected["node_id"])
-          expect(node_actual["short_name"]).to eq(node_expected["short_name"])
-          expect(node_actual["long_name"]).to eq(node_expected["long_name"])
-          expect(node_actual["role"]).to eq(node_expected["role"])
-          expect_same_value(node_actual["snr"], node_expected["snr"])
-          expect(node_actual["lora_freq"]).to eq(node_expected["lora_freq"])
-          expect(node_actual["modem_preset"]).to eq(node_expected["modem_preset"])
-          expect_same_value(node_actual["battery_level"], node_expected["battery_level"])
-          expect_same_value(node_actual["voltage"], node_expected["voltage"])
-          expected_last_heard = node_expected["last_heard"]
-          latest_rx = latest_rx_by_node[node_expected["node_id"]]
-          if latest_rx
-            expected_last_heard = [expected_last_heard, latest_rx].compact.max
-          end
-          expect(node_actual["last_heard"]).to eq(expected_last_heard)
-          expect(node_actual["first_heard"]).to eq(node_expected["first_heard"])
-          expect_same_value(node_actual["latitude"], node_expected["latitude"])
-          expect_same_value(node_actual["longitude"], node_expected["longitude"])
-          expect_same_value(node_actual["altitude"], node_expected["altitude"])
-        else
-          expect(actual_row["node"]).to be_a(Hash)
-          expect(actual_row["node"]["node_id"]).to be_nil
-        end
+        expect(actual_row["rx_time"]).to eq(expected["rx_time"])
+        expect(actual_row["rx_iso"]).to eq(expected["rx_iso"])
+        expect(actual_row).not_to have_key("node")
       end
     end
-
     context "when DEBUG logging is enabled" do
       it "logs diagnostics for messages missing a sender" do
         allow(PotatoMesh::Config).to receive(:debug?).and_return(true)
@@ -3248,28 +3186,19 @@ RSpec.describe "Potato Mesh Sinatra app" do
         expect(PotatoMesh::Logging).to have_received(:log).with(
           kind_of(Logger),
           :debug,
-          "Message join produced empty sender",
+          "Message query produced empty sender",
           context: "queries.messages",
-          stage: "before_join",
+          stage: "raw_row",
           row: a_hash_including("id" => message_id),
         )
         expect(PotatoMesh::Logging).to have_received(:log).with(
           kind_of(Logger),
           :debug,
-          "Message join produced empty sender",
+          "Message query produced empty sender",
           context: "queries.messages",
-          stage: "after_join",
+          stage: "after_normalization",
           row: a_hash_including("id" => message_id),
         )
-        expect(PotatoMesh::Logging).to have_received(:log).with(
-          kind_of(Logger),
-          :debug,
-          "Message row missing sender after processing",
-          context: "queries.messages",
-          stage: "after_processing",
-          row: a_hash_including("id" => message_id),
-        )
-
         messages = JSON.parse(last_response.body)
         expect(messages.size).to eq(1)
         expect(messages.first["from_id"]).to be_nil


### PR DESCRIPTION
## Summary
- stop joining node records in the messages query and expose canonical node_id fields instead
- add a browser-side message node hydrator to fetch missing node metadata on demand
- update API specs and tests to cover the slimmer message payload and new hydration flow
- fix #354 

## Testing
- rufo .
- black .
- pytest
- bundle exec rspec
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68f0104f2618832b847a8497b152621d