### PR TITLE
Add federation ingestion limits and tests

### DIFF
--- a/web/lib/potato_mesh/application/routes/ingest.rb
+++ b/web/lib/potato_mesh/application/routes/ingest.rb
@@ -225,7 +225,12 @@ module PotatoMesh
 
             db = open_database
             upsert_instance_record(db, attributes, signature)
-            ingest_known_instances_from!(db, attributes[:domain])
+            ingest_known_instances_from!(
+              db,
+              attributes[:domain],
+              per_response_limit: PotatoMesh::Config.federation_max_instances_per_response,
+              overall_limit: PotatoMesh::Config.federation_max_domains_per_crawl,
+            )
             debug_log(
               "Registered remote instance",
               context: "ingest.register",

--- a/web/spec/config_spec.rb
+++ b/web/spec/config_spec.rb
@@ -169,6 +169,54 @@ RSpec.describe PotatoMesh::Config do
     end
   end
 
+  describe ".federation_max_instances_per_response" do
+    it "returns the baked-in response limit when unset" do
+      within_env("FEDERATION_MAX_INSTANCES_PER_RESPONSE" => nil) do
+        expect(described_class.federation_max_instances_per_response).to eq(
+          PotatoMesh::Config::DEFAULT_FEDERATION_MAX_INSTANCES_PER_RESPONSE,
+        )
+      end
+    end
+
+    it "accepts positive overrides" do
+      within_env("FEDERATION_MAX_INSTANCES_PER_RESPONSE" => "7") do
+        expect(described_class.federation_max_instances_per_response).to eq(7)
+      end
+    end
+
+    it "rejects non-positive overrides" do
+      within_env("FEDERATION_MAX_INSTANCES_PER_RESPONSE" => "0") do
+        expect(described_class.federation_max_instances_per_response).to eq(
+          PotatoMesh::Config::DEFAULT_FEDERATION_MAX_INSTANCES_PER_RESPONSE,
+        )
+      end
+    end
+  end
+
+  describe ".federation_max_domains_per_crawl" do
+    it "returns the baked-in crawl limit when unset" do
+      within_env("FEDERATION_MAX_DOMAINS_PER_CRAWL" => nil) do
+        expect(described_class.federation_max_domains_per_crawl).to eq(
+          PotatoMesh::Config::DEFAULT_FEDERATION_MAX_DOMAINS_PER_CRAWL,
+        )
+      end
+    end
+
+    it "accepts positive overrides" do
+      within_env("FEDERATION_MAX_DOMAINS_PER_CRAWL" => "11") do
+        expect(described_class.federation_max_domains_per_crawl).to eq(11)
+      end
+    end
+
+    it "rejects invalid overrides" do
+      within_env("FEDERATION_MAX_DOMAINS_PER_CRAWL" => "-5") do
+        expect(described_class.federation_max_domains_per_crawl).to eq(
+          PotatoMesh::Config::DEFAULT_FEDERATION_MAX_DOMAINS_PER_CRAWL,
+        )
+      end
+    end
+  end
+
   describe ".db_path" do
     it "returns the default path inside the data directory" do
       expect(described_class.db_path).to eq(described_class.default_db_path)


### PR DESCRIPTION
## Summary
- add configurable federation crawl limits and helper parsing for positive integer settings
- enforce response and crawl caps when ingesting instances via the federation crawler and registration route
- cover the new behaviour with federation ingestion specs and configuration unit tests

## Testing
- pytest
- bundle exec rspec
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f0e685a6a4832bad12dfe6c40834d2