### PR TITLE
Delay initial federation announcements

### DIFF
--- a/web/lib/potato_mesh/application/federation.rb
+++ b/web/lib/potato_mesh/application/federation.rb
@@ -273,12 +273,17 @@ module PotatoMesh
         thread
       end
 
+      # Launch a background thread responsible for the first federation broadcast.
+      #
+      # @return [Thread, nil] the thread handling the initial announcement.
       def start_initial_federation_announcement!
         existing = settings.respond_to?(:initial_federation_thread) ? settings.initial_federation_thread : nil
         return existing if existing&.alive?
 
         thread = Thread.new do
           begin
+            delay = PotatoMesh::Config.initial_federation_delay_seconds
+            Kernel.sleep(delay) if delay.positive?
             announce_instance_to_all_domains
           rescue StandardError => e
             warn_log(

--- a/web/lib/potato_mesh/config.rb
+++ b/web/lib/potato_mesh/config.rb
@@ -36,6 +36,7 @@ module PotatoMesh
     DEFAULT_REMOTE_INSTANCE_READ_TIMEOUT = 12
     DEFAULT_FEDERATION_MAX_INSTANCES_PER_RESPONSE = 64
     DEFAULT_FEDERATION_MAX_DOMAINS_PER_CRAWL = 256
+    DEFAULT_INITIAL_FEDERATION_DELAY_SECONDS = 2
 
     # Resolve the absolute path to the web application root directory.
     #
@@ -333,6 +334,16 @@ module PotatoMesh
     # @return [Integer] number of seconds between announcement cycles.
     def federation_announcement_interval
       8 * 60 * 60
+    end
+
+    # Determine the grace period before sending the initial federation announcement.
+    #
+    # @return [Integer] seconds to wait before the first broadcast cycle.
+    def initial_federation_delay_seconds
+      fetch_positive_integer(
+        "INITIAL_FEDERATION_DELAY_SECONDS",
+        DEFAULT_INITIAL_FEDERATION_DELAY_SECONDS,
+      )
     end
 
     # Retrieve the configured site name for presentation.

--- a/web/spec/app_spec.rb
+++ b/web/spec/app_spec.rb
@@ -249,7 +249,10 @@ RSpec.describe "Potato Mesh Sinatra app" do
     end
 
     it "stores and clears the initial federation thread" do
-      allow(app).to receive(:announce_instance_to_all_domains)
+      delay = 3
+      allow(PotatoMesh::Config).to receive(:initial_federation_delay_seconds).and_return(delay)
+      expect(Kernel).to receive(:sleep).with(delay)
+      expect(app).to receive(:announce_instance_to_all_domains)
       allow(Thread).to receive(:new) do |&block|
         dummy_thread.block = block
         dummy_thread


### PR DESCRIPTION
## Summary
- add a configurable grace period before broadcasting the initial federation announcement
- expose the INITIAL_FEDERATION_DELAY_SECONDS configuration option with a sensible default
- update the federation spec to assert the startup delay behaviour

## Testing
- rufo .
- black .
- pytest
- bundle exec rspec
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f14ac17f34832b9f66f08d3ce045a8