### PR TITLE
Fixes POST request 403 errors on instances behind Cloudflare proxy

### DIFF
--- a/data/mesh_ingestor/queue.py
+++ b/data/mesh_ingestor/queue.py
@@ -72,11 +72,22 @@ def _post_json(
         return
     url = f"{instance}{path}"
     data = json.dumps(payload).encode("utf-8")
+
+    # Add full headers to avoid Cloudflare blocks on instances behind cloudflare proxy
     req = urllib.request.Request(
-        url, data=data, headers={"Content-Type": "application/json"}
+        url,
+        data=data,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {api_token}",
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+            "Accept": "application/json",
+            "Accept-Language": "en-US,en;q=0.9",
+            "Origin": f"{instance}",
+            "Referer": f"{instance}"
+        }
     )
-    if api_token:
-        req.add_header("Authorization", f"Bearer {api_token}")
+
     try:
         with urllib.request.urlopen(req, timeout=10) as resp:
             resp.read()


### PR DESCRIPTION
Add full headers to ingestor POST requests to avoid Cloudflare bans