### PR TITLE
Expose FEDERATION environment option across tooling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,9 @@ MAX_DISTANCE=42
 # Matrix aliases (e.g. #meshtastic-berlin:matrix.org) will be linked via matrix.to automatically.
 CONTACT_LINK='#potatomesh:dod.ngo'
 
+# Enable or disable PotatoMesh federation features (1=enabled, 0=disabled)
+FEDERATION=1
+
 
 # =============================================================================
 # ADVANCED SETTINGS

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The web app can be configured with environment variables (defaults shown):
 * `CONTACT_LINK` - chat link or Matrix alias for footer and overlay (default: `#potatomesh:dod.ngo`)
 * `PRIVATE` - set to `1` to hide the chat UI, disable message APIs, and exclude hidden clients (default: unset)
 * `INSTANCE_DOMAIN` - public hostname (optionally with port) used for metadata, federation, and API links (default: auto-detected)
+* `FEDERATION` - set to `1` to announce your instance and crawl peers, or `0` to disable federation (default: `1`)
 
 The application derives SEO-friendly document titles, descriptions, and social
 preview tags from these existing configuration values and reuses the bundled
@@ -100,6 +101,17 @@ well-known document is staged in
 `$XDG_CONFIG_HOME/potato-mesh/well-known/potato-mesh`.
 
 The database can be found in `$XDG_DATA_HOME/potato-mesh`.
+
+### Federation
+
+PotatoMesh instances can optionally federate by publishing signed metadata and
+discovering peers. Federation is enabled by default and controlled with the
+`FEDERATION` environment variable. Set `FEDERATION=1` (default) to announce your
+instance, respond to remote crawlers, and crawl the wider network. Set
+`FEDERATION=0` to keep your deployment isolated—federation requests will be
+ignored and the ingestor will skip discovery tasks. Private mode still takes
+precedence; when `PRIVATE=1`, federation features remain disabled regardless of
+the `FEDERATION` value.
 
 ### API
 

--- a/configure.sh
+++ b/configure.sh
@@ -70,6 +70,7 @@ update_env() {
 SITE_NAME=$(grep "^SITE_NAME=" .env 2>/dev/null | cut -d'=' -f2- | tr -d '"' || echo "PotatoMesh Demo")
 CHANNEL=$(grep "^CHANNEL=" .env 2>/dev/null | cut -d'=' -f2- | tr -d '"' || echo "#LongFast")
 FREQUENCY=$(grep "^FREQUENCY=" .env 2>/dev/null | cut -d'=' -f2- | tr -d '"' || echo "915MHz")
+FEDERATION=$(grep "^FEDERATION=" .env 2>/dev/null | cut -d'=' -f2- | tr -d '"' || echo "1")
 MAP_CENTER=$(grep "^MAP_CENTER=" .env 2>/dev/null | cut -d'=' -f2- | tr -d '"' || echo "38.761944,-27.090833")
 MAX_DISTANCE=$(grep "^MAX_DISTANCE=" .env 2>/dev/null | cut -d'=' -f2- | tr -d '"' || echo "42")
 CONTACT_LINK=$(grep "^CONTACT_LINK=" .env 2>/dev/null | cut -d'=' -f2- | tr -d '"' || echo "#potatomesh:dod.ngo")
@@ -93,6 +94,13 @@ echo ""
 echo "💬 Optional Settings"
 echo "-------------------"
 read_with_default "Chat link or Matrix room (optional)" "$CONTACT_LINK" CONTACT_LINK
+
+echo ""
+echo "🤝 Federation Settings"
+echo "----------------------"
+echo "Federation shares instance metadata with other PotatoMesh deployments."
+echo "Set to 1 to enable discovery or 0 to keep your instance isolated."
+read_with_default "Enable federation (1=yes, 0=no)" "$FEDERATION" FEDERATION
 
 echo ""
 echo "🛠 Docker Settings"
@@ -150,6 +158,7 @@ update_env "MAX_DISTANCE" "$MAX_DISTANCE"
 update_env "CONTACT_LINK" "\"$CONTACT_LINK\""
 update_env "API_TOKEN" "$API_TOKEN"
 update_env "POTATOMESH_IMAGE_ARCH" "$POTATOMESH_IMAGE_ARCH"
+update_env "FEDERATION" "$FEDERATION"
 if [ -n "$INSTANCE_DOMAIN" ]; then
     update_env "INSTANCE_DOMAIN" "$INSTANCE_DOMAIN"
 else
@@ -190,6 +199,11 @@ echo "   Chat: ${CONTACT_LINK:-'Not set'}"
 echo "   API Token: ${API_TOKEN:0:8}..."
 echo "   Docker Image Arch: $POTATOMESH_IMAGE_ARCH"
 echo "   Instance Domain: ${INSTANCE_DOMAIN:-'Auto-detected'}"
+if [ "${FEDERATION:-1}" = "0" ]; then
+    echo "   Federation: Disabled"
+else
+    echo "   Federation: Enabled"
+fi
 echo ""
 echo "🚀 You can now start PotatoMesh with:"
 echo "   docker-compose up -d"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ x-web-base: &web-base
     MAP_CENTER: ${MAP_CENTER:-38.761944,-27.090833}
     MAX_DISTANCE: ${MAX_DISTANCE:-42}
     CONTACT_LINK: ${CONTACT_LINK:-#potatomesh:dod.ngo}
+    FEDERATION: ${FEDERATION:-1}
     API_TOKEN: ${API_TOKEN}
     INSTANCE_DOMAIN: ${INSTANCE_DOMAIN}
     DEBUG: ${DEBUG:-0}
@@ -36,6 +37,7 @@ x-ingestor-base: &ingestor-base
     API_TOKEN: ${API_TOKEN}
     INSTANCE_DOMAIN: ${INSTANCE_DOMAIN}
     DEBUG: ${DEBUG:-0}
+    FEDERATION: ${FEDERATION:-1}
   volumes:
     - potatomesh_data:/app/.local/share/potato-mesh
     - potatomesh_config:/app/.config/potato-mesh


### PR DESCRIPTION
## Summary
- add FEDERATION prompt and persistence to the interactive configuration script
- propagate the FEDERATION environment variable to docker-compose defaults and the sample .env file
- document how to control PotatoMesh federation features in the README

## Testing
- rufo .
- black .
- pytest
- rspec
- npm test *(fails: repository has no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68f2a281c1a4832bbc460226099b32a1