### PR TITLE
Expose PRIVATE environment configuration across tooling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,9 @@ CONTACT_LINK='#potatomesh:dod.ngo'
 # Enable or disable PotatoMesh federation features (1=enabled, 0=disabled)
 FEDERATION=1
 
+# Hide public mesh messages from unauthenticated visitors (1=hidden, 0=public)
+PRIVATE=0
+
 
 # =============================================================================
 # ADVANCED SETTINGS

--- a/configure.sh
+++ b/configure.sh
@@ -71,6 +71,7 @@ SITE_NAME=$(grep "^SITE_NAME=" .env 2>/dev/null | cut -d'=' -f2- | tr -d '"' || 
 CHANNEL=$(grep "^CHANNEL=" .env 2>/dev/null | cut -d'=' -f2- | tr -d '"' || echo "#LongFast")
 FREQUENCY=$(grep "^FREQUENCY=" .env 2>/dev/null | cut -d'=' -f2- | tr -d '"' || echo "915MHz")
 FEDERATION=$(grep "^FEDERATION=" .env 2>/dev/null | cut -d'=' -f2- | tr -d '"' || echo "1")
+PRIVATE=$(grep "^PRIVATE=" .env 2>/dev/null | cut -d'=' -f2- | tr -d '"' || echo "0")
 MAP_CENTER=$(grep "^MAP_CENTER=" .env 2>/dev/null | cut -d'=' -f2- | tr -d '"' || echo "38.761944,-27.090833")
 MAX_DISTANCE=$(grep "^MAX_DISTANCE=" .env 2>/dev/null | cut -d'=' -f2- | tr -d '"' || echo "42")
 CONTACT_LINK=$(grep "^CONTACT_LINK=" .env 2>/dev/null | cut -d'=' -f2- | tr -d '"' || echo "#potatomesh:dod.ngo")
@@ -101,6 +102,13 @@ echo "----------------------"
 echo "Federation shares instance metadata with other PotatoMesh deployments."
 echo "Set to 1 to enable discovery or 0 to keep your instance isolated."
 read_with_default "Enable federation (1=yes, 0=no)" "$FEDERATION" FEDERATION
+
+echo ""
+echo "🙈 Privacy Settings"
+echo "-------------------"
+echo "Private mode hides public mesh messages from unauthenticated visitors."
+echo "Set to 1 to hide public feeds or 0 to keep them visible."
+read_with_default "Enable private mode (1=yes, 0=no)" "$PRIVATE" PRIVATE
 
 echo ""
 echo "🛠 Docker Settings"
@@ -159,6 +167,7 @@ update_env "CONTACT_LINK" "\"$CONTACT_LINK\""
 update_env "API_TOKEN" "$API_TOKEN"
 update_env "POTATOMESH_IMAGE_ARCH" "$POTATOMESH_IMAGE_ARCH"
 update_env "FEDERATION" "$FEDERATION"
+update_env "PRIVATE" "$PRIVATE"
 if [ -n "$INSTANCE_DOMAIN" ]; then
     update_env "INSTANCE_DOMAIN" "$INSTANCE_DOMAIN"
 else
@@ -198,6 +207,7 @@ echo "   Frequency: $FREQUENCY"
 echo "   Chat: ${CONTACT_LINK:-'Not set'}"
 echo "   API Token: ${API_TOKEN:0:8}..."
 echo "   Docker Image Arch: $POTATOMESH_IMAGE_ARCH"
+echo "   Private Mode: ${PRIVATE}"
 echo "   Instance Domain: ${INSTANCE_DOMAIN:-'Auto-detected'}"
 if [ "${FEDERATION:-1}" = "0" ]; then
     echo "   Federation: Disabled"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ x-web-base: &web-base
     MAX_DISTANCE: ${MAX_DISTANCE:-42}
     CONTACT_LINK: ${CONTACT_LINK:-#potatomesh:dod.ngo}
     FEDERATION: ${FEDERATION:-1}
+    PRIVATE: ${PRIVATE:-0}
     API_TOKEN: ${API_TOKEN}
     INSTANCE_DOMAIN: ${INSTANCE_DOMAIN}
     DEBUG: ${DEBUG:-0}
@@ -38,6 +39,7 @@ x-ingestor-base: &ingestor-base
     INSTANCE_DOMAIN: ${INSTANCE_DOMAIN}
     DEBUG: ${DEBUG:-0}
     FEDERATION: ${FEDERATION:-1}
+    PRIVATE: ${PRIVATE:-0}
   volumes:
     - potatomesh_data:/app/.local/share/potato-mesh
     - potatomesh_config:/app/.config/potato-mesh


### PR DESCRIPTION
## Summary
- propagate the PRIVATE environment variable through the shared docker-compose service configuration
- extend the interactive configure.sh helper to capture and persist the PRIVATE flag
- document the PRIVATE toggle in the sample environment configuration

## Testing
- black .
- rufo .
- pytest
- rspec
- npm test *(fails: package.json not present)*

------
https://chatgpt.com/codex/tasks/task_e_68f2a85d2130832bb48b587a014954a8