### PR TITLE
Ensure private mode disables chat messaging

### DIFF
--- a/web/lib/potato_mesh/application/helpers.rb
+++ b/web/lib/potato_mesh/application/helpers.rb
@@ -323,7 +323,7 @@ module PotatoMesh
       #
       # @return [Boolean] true when PRIVATE=1.
       def private_mode?
-        ENV["PRIVATE"] == "1"
+        PotatoMesh::Config.private_mode_enabled?
       end
 
       # Identify whether the Rack environment corresponds to the test suite.

--- a/web/lib/potato_mesh/application/routes/api.rb
+++ b/web/lib/potato_mesh/application/routes/api.rb
@@ -17,6 +17,10 @@ module PotatoMesh
     module Routes
       module Api
         def self.registered(app)
+          app.before "/api/messages*" do
+            halt 404 if private_mode?
+          end
+
           app.get "/version" do
             content_type :json
             last_update = latest_node_update_timestamp
@@ -67,14 +71,12 @@ module PotatoMesh
           end
 
           app.get "/api/messages" do
-            halt 404 if private_mode?
             content_type :json
             limit = [params["limit"]&.to_i || 200, 1000].min
             query_messages(limit).to_json
           end
 
           app.get "/api/messages/:id" do
-            halt 404 if private_mode?
             content_type :json
             node_ref = string_or_nil(params["id"])
             halt 400, { error: "missing node id" }.to_json unless node_ref

--- a/web/lib/potato_mesh/application/routes/ingest.rb
+++ b/web/lib/potato_mesh/application/routes/ingest.rb
@@ -40,7 +40,6 @@ module PotatoMesh
           end
 
           app.post "/api/messages" do
-            halt 404 if private_mode?
             require_token!
             content_type :json
             begin

--- a/web/lib/potato_mesh/config.rb
+++ b/web/lib/potato_mesh/config.rb
@@ -38,6 +38,14 @@ module PotatoMesh
     DEFAULT_FEDERATION_MAX_DOMAINS_PER_CRAWL = 256
     DEFAULT_INITIAL_FEDERATION_DELAY_SECONDS = 2
 
+    # Determine whether private mode should be activated.
+    #
+    # @return [Boolean] true when PRIVATE=1 in the environment.
+    def private_mode_enabled?
+      value = ENV.fetch("PRIVATE", "0")
+      value.to_s.strip == "1"
+    end
+
     # Resolve the absolute path to the web application root directory.
     #
     # @return [String] absolute filesystem path of the web folder.

--- a/web/spec/app_spec.rb
+++ b/web/spec/app_spec.rb
@@ -3386,6 +3386,11 @@ RSpec.describe "Potato Mesh Sinatra app" do
       expect(last_response.status).to eq(404)
     end
 
+    it "returns 404 for HEAD /api/messages" do
+      head "/api/messages"
+      expect(last_response.status).to eq(404)
+    end
+
     it "returns 404 for POST /api/messages" do
       post "/api/messages", {}.to_json, auth_headers
       expect(last_response.status).to eq(404)

--- a/web/spec/config_spec.rb
+++ b/web/spec/config_spec.rb
@@ -115,6 +115,32 @@ RSpec.describe PotatoMesh::Config do
     end
   end
 
+  describe ".private_mode_enabled?" do
+    it "returns false when PRIVATE is unset" do
+      within_env("PRIVATE" => nil) do
+        expect(described_class.private_mode_enabled?).to be(false)
+      end
+    end
+
+    it "returns false when PRIVATE=0" do
+      within_env("PRIVATE" => "0") do
+        expect(described_class.private_mode_enabled?).to be(false)
+      end
+    end
+
+    it "returns true when PRIVATE=1" do
+      within_env("PRIVATE" => "1") do
+        expect(described_class.private_mode_enabled?).to be(true)
+      end
+    end
+
+    it "ignores surrounding whitespace" do
+      within_env("PRIVATE" => "  1  ") do
+        expect(described_class.private_mode_enabled?).to be(true)
+      end
+    end
+  end
+
   describe ".legacy_well_known_candidates" do
     it "includes repository config directories" do
       Dir.mktmpdir do |dir|


### PR DESCRIPTION
## Summary
- add a configuration helper to determine when private mode is enabled
- gate all /api/messages requests behind a shared filter and reuse the helper in application code
- extend the private mode test suite to cover HEAD requests and configuration behaviour

## Testing
- pytest
- bundle exec rspec
- npm test
- black .
- rufo .

------
https://chatgpt.com/codex/tasks/task_e_68f2a8e60fc0832baedee37a5b915d0e