### PR TITLE
Disable federation features when FEDERATION=0

### DIFF
--- a/web/lib/potato_mesh/application/federation.rb
+++ b/web/lib/potato_mesh/application/federation.rb
@@ -250,6 +250,9 @@ module PotatoMesh
       end
 
       def start_federation_announcer!
+        # Federation broadcasts must not execute when federation support is disabled.
+        return nil unless federation_enabled?
+
         existing = settings.federation_thread
         return existing if existing&.alive?
 
@@ -277,6 +280,9 @@ module PotatoMesh
       #
       # @return [Thread, nil] the thread handling the initial announcement.
       def start_initial_federation_announcement!
+        # Skip the initial broadcast entirely when federation is disabled.
+        return nil unless federation_enabled?
+
         existing = settings.respond_to?(:initial_federation_thread) ? settings.initial_federation_thread : nil
         return existing if existing&.alive?
 

--- a/web/lib/potato_mesh/application/routes/api.rb
+++ b/web/lib/potato_mesh/application/routes/api.rb
@@ -125,6 +125,9 @@ module PotatoMesh
           end
 
           app.get "/api/instances" do
+            # Prevent the federation catalog from being exposed when federation is disabled.
+            halt 404 unless federation_enabled?
+
             content_type :json
             ensure_self_instance_record!
             payload = load_instances_for_api


### PR DESCRIPTION
## Summary
- halt the `/api/instances` endpoint when the FEDERATION flag disables federation
- prevent federation announcer threads from starting if federation is turned off
- add regression specs to cover the disabled federation behaviour

## Testing
- rufo .
- black .
- bundle exec rspec
- npm test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f2a949ba7c832ba00fe9c485e2bbc6