### PR TITLE
Ensure private mode disables federation

### DIFF
--- a/web/lib/potato_mesh/application/helpers.rb
+++ b/web/lib/potato_mesh/application/helpers.rb
@@ -337,7 +337,7 @@ module PotatoMesh
       #
       # @return [Boolean] true when federation configuration allows it.
       def federation_enabled?
-        ENV.fetch("FEDERATION", "1") != "0" && !private_mode?
+        PotatoMesh::Config.federation_enabled?
       end
 
       # Determine whether federation announcements should run asynchronously.

--- a/web/lib/potato_mesh/config.rb
+++ b/web/lib/potato_mesh/config.rb
@@ -46,6 +46,20 @@ module PotatoMesh
       value.to_s.strip == "1"
     end
 
+    # Determine whether federation features are permitted for the instance.
+    #
+    # Federation is disabled when ``PRIVATE=1`` regardless of the
+    # ``FEDERATION`` environment variable to ensure a private deployment does
+    # not announce itself or crawl peers.
+    #
+    # @return [Boolean] true when federation should remain active.
+    def federation_enabled?
+      return false if private_mode_enabled?
+
+      value = ENV.fetch("FEDERATION", "1")
+      value.to_s.strip != "0"
+    end
+
     # Resolve the absolute path to the web application root directory.
     #
     # @return [String] absolute filesystem path of the web folder.

--- a/web/spec/config_spec.rb
+++ b/web/spec/config_spec.rb
@@ -141,6 +141,32 @@ RSpec.describe PotatoMesh::Config do
     end
   end
 
+  describe ".federation_enabled?" do
+    it "returns true when FEDERATION is unset" do
+      within_env("FEDERATION" => nil, "PRIVATE" => "0") do
+        expect(described_class.federation_enabled?).to be(true)
+      end
+    end
+
+    it "returns false when FEDERATION=0" do
+      within_env("FEDERATION" => "0", "PRIVATE" => "0") do
+        expect(described_class.federation_enabled?).to be(false)
+      end
+    end
+
+    it "returns false when PRIVATE=1" do
+      within_env("FEDERATION" => "1", "PRIVATE" => "1") do
+        expect(described_class.federation_enabled?).to be(false)
+      end
+    end
+
+    it "ignores surrounding whitespace" do
+      within_env("FEDERATION" => " 0 ", "PRIVATE" => "0") do
+        expect(described_class.federation_enabled?).to be(false)
+      end
+    end
+  end
+
   describe ".legacy_well_known_candidates" do
     it "includes repository config directories" do
       Dir.mktmpdir do |dir|


### PR DESCRIPTION
## Summary
- add a configuration helper that forces federation off when PRIVATE=1
- reuse the shared configuration logic from the web helpers
- cover the new behaviour with configuration specs

## Testing
- rufo .
- black .
- pytest
- bundle exec rspec
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f2ab97a7d8832bbf5d993e7272631c