### PR TITLE
Harden federation announcements

### DIFF
--- a/web/lib/potato_mesh/config.rb
+++ b/web/lib/potato_mesh/config.rb
@@ -32,8 +32,8 @@ module PotatoMesh
     DEFAULT_FREQUENCY = "915MHz"
     DEFAULT_CONTACT_LINK = "#potatomesh:dod.ngo"
     DEFAULT_MAX_DISTANCE_KM = 42.0
-    DEFAULT_REMOTE_INSTANCE_CONNECT_TIMEOUT = 5
-    DEFAULT_REMOTE_INSTANCE_READ_TIMEOUT = 12
+    DEFAULT_REMOTE_INSTANCE_CONNECT_TIMEOUT = 15
+    DEFAULT_REMOTE_INSTANCE_READ_TIMEOUT = 60
     DEFAULT_FEDERATION_MAX_INSTANCES_PER_RESPONSE = 64
     DEFAULT_FEDERATION_MAX_DOMAINS_PER_CRAWL = 256
     DEFAULT_INITIAL_FEDERATION_DELAY_SECONDS = 2
@@ -284,16 +284,28 @@ module PotatoMesh
 
     # Connection timeout used when establishing federation HTTP sockets.
     #
+    # The timeout can be customised with the REMOTE_INSTANCE_CONNECT_TIMEOUT
+    # environment variable to accommodate slower or distant federation peers.
+    #
     # @return [Integer] connect timeout in seconds.
     def remote_instance_http_timeout
-      DEFAULT_REMOTE_INSTANCE_CONNECT_TIMEOUT
+      fetch_positive_integer(
+        "REMOTE_INSTANCE_CONNECT_TIMEOUT",
+        DEFAULT_REMOTE_INSTANCE_CONNECT_TIMEOUT,
+      )
     end
 
     # Read timeout used when streaming federation HTTP responses.
     #
+    # The timeout can be customised with the REMOTE_INSTANCE_READ_TIMEOUT
+    # environment variable to accommodate slower or distant federation peers.
+    #
     # @return [Integer] read timeout in seconds.
     def remote_instance_read_timeout
-      DEFAULT_REMOTE_INSTANCE_READ_TIMEOUT
+      fetch_positive_integer(
+        "REMOTE_INSTANCE_READ_TIMEOUT",
+        DEFAULT_REMOTE_INSTANCE_READ_TIMEOUT,
+      )
     end
 
     # Limit the number of remote instances processed from a single response.

--- a/web/spec/config_spec.rb
+++ b/web/spec/config_spec.rb
@@ -164,14 +164,22 @@ RSpec.describe PotatoMesh::Config do
   end
 
   describe ".remote_instance_http_timeout" do
-    it "returns the baked-in connect timeout" do
-      expect(described_class.remote_instance_http_timeout).to eq(
-        PotatoMesh::Config::DEFAULT_REMOTE_INSTANCE_CONNECT_TIMEOUT,
-      )
+    it "returns the baked-in connect timeout when unset" do
+      within_env("REMOTE_INSTANCE_CONNECT_TIMEOUT" => nil) do
+        expect(described_class.remote_instance_http_timeout).to eq(
+          PotatoMesh::Config::DEFAULT_REMOTE_INSTANCE_CONNECT_TIMEOUT,
+        )
+      end
     end
 
-    it "ignores environment overrides" do
+    it "accepts positive environment overrides" do
       within_env("REMOTE_INSTANCE_CONNECT_TIMEOUT" => "27") do
+        expect(described_class.remote_instance_http_timeout).to eq(27)
+      end
+    end
+
+    it "rejects non-positive overrides" do
+      within_env("REMOTE_INSTANCE_CONNECT_TIMEOUT" => "0") do
         expect(described_class.remote_instance_http_timeout).to eq(
           PotatoMesh::Config::DEFAULT_REMOTE_INSTANCE_CONNECT_TIMEOUT,
         )
@@ -180,14 +188,22 @@ RSpec.describe PotatoMesh::Config do
   end
 
   describe ".remote_instance_read_timeout" do
-    it "returns the baked-in read timeout" do
-      expect(described_class.remote_instance_read_timeout).to eq(
-        PotatoMesh::Config::DEFAULT_REMOTE_INSTANCE_READ_TIMEOUT,
-      )
+    it "returns the baked-in read timeout when unset" do
+      within_env("REMOTE_INSTANCE_READ_TIMEOUT" => nil) do
+        expect(described_class.remote_instance_read_timeout).to eq(
+          PotatoMesh::Config::DEFAULT_REMOTE_INSTANCE_READ_TIMEOUT,
+        )
+      end
     end
 
-    it "ignores environment overrides" do
+    it "accepts positive overrides" do
       within_env("REMOTE_INSTANCE_READ_TIMEOUT" => "20") do
+        expect(described_class.remote_instance_read_timeout).to eq(20)
+      end
+    end
+
+    it "rejects non-positive overrides" do
+      within_env("REMOTE_INSTANCE_READ_TIMEOUT" => "-5") do
         expect(described_class.remote_instance_read_timeout).to eq(
           PotatoMesh::Config::DEFAULT_REMOTE_INSTANCE_READ_TIMEOUT,
         )


### PR DESCRIPTION
## Summary
- skip federation announcement targets whose last update is older than a week
- centralise HTTP request construction with descriptive headers for federation traffic
- raise default federation HTTP timeouts to 15s connect / 60s read and cover the new behaviour in specs

## Testing
- bundle exec rspec
- pytest
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f3454fcd8c832bb74e975c769148cb