### PR TITLE
feat: Mesh-Ingestor: Ability to provide already-existing interface instance

### DIFF
--- a/data/mesh_ingestor/daemon.py
+++ b/data/mesh_ingestor/daemon.py
@@ -218,7 +218,7 @@ def main(existing_interface=None) -> None:
             topics=subscribed,
         )
 
-    iface = None if existing_interface is None else existing_interface
+    iface = existing_interface
     resolved_target = None
     retry_delay = max(0.0, config._RECONNECT_INITIAL_DELAY_SECS)
 


### PR DESCRIPTION
# Summary
I am currently developing my own tiny meshtatsic bot/packettracer/logger/... python script.
While my python script is running, potato-mesh cannot access the node's interface at the same time.


As a solution, this PR adds an `existing_interface` parameter to the daemon main method, which allows passing an already existing mestastic interface instance. This solves my problem, as it allows potato-mesh to run alongside another script.
Code changes are minimal and non-invasive.

An existing interface can be provided like in this example this:
```python
import meshtastic
import meshtastic.tcp_interface
from threading import Thread

interface = meshtastic.tcp_interface.TCPInterface(hostname="192.168.254.137")
print(interface.getMyNodeInfo())

import mesh

runAsThread = False
if runAsThread:
    t = Thread(target=mesh.main, args=(interface,), daemon=True)
    t.start()
else:
    mesh.main(interface)    
```

Edit: There was also an error when registering the sigterm signals if potato-mesh is run as a (non-main-)thread.
Added a conditional check there as well.
