### PR TITLE
fix: Mesh-Ingestor: Fix error for non-existing datetime.UTC reference

### DIFF
--- a/data/mesh_ingestor/serialization.py
+++ b/data/mesh_ingestor/serialization.py
@@ -120,7 +120,7 @@ def _iso(ts: int | float) -> str:
     import datetime
 
     return (
-        datetime.datetime.fromtimestamp(int(ts), datetime.UTC)
+        datetime.datetime.fromtimestamp(int(ts), datetime.timezone.utc)
         .isoformat()
         .replace("+00:00", "Z")
     )


### PR DESCRIPTION
# Summary

My logs show the following error:
```
[2025-10-26T13:42:27.300Z] [potato-mesh] [warn] context=handlers.on_receive error_class='AttributeError' error_message="module 'datetime' has no attribute 'UTC'" packet_info=['from', 'to', 'channel', 'encrypted', 'id', 'rxTime', 'rxSnr', 'hopLimit', 'rxRssi', 'hopStart', 'relayNode', 'transportMechanism', 'raw', 'fromId', 'toId', '_potatomesh_seen'] Failed to store packet
```
The error is caused by using `datetime.UTC` instead of `datetime.timezone.utc` in serialization.py.

