### PR TITLE
Config: Read PROM_REPORT_IDS from environment

### DIFF
--- a/web/lib/potato_mesh/config.rb
+++ b/web/lib/potato_mesh/config.rb
@@ -201,7 +201,7 @@ module PotatoMesh
     #
     # @return [String] comma separated list of report IDs.
     def prom_report_ids
-      ""
+      fetch_string("PROM_REPORT_IDS", "")
     end
 
     # Transform Prometheus report identifiers into a cleaned array.


### PR DESCRIPTION
I think a recent PR broke the ability to report on specific meshtastic IDs through the Prometheus `/metrics` endpoint.

I needed to change this line in `config.rb` to read from the `PROM_REPORT_IDS` environment variable, otherwise it's always `""` so there was no way (that I could tell?) to specify which IDS to report on.

I wasn't sure why `PROM_REPORT_IDS` was removed from the README as well in this commit:

https://github.com/l5yth/potato-mesh/commit/dee6ad7e4a972fc97088de7c5d56bb6a9532bd7b