### PR TITLE
Handle missing instance domain outside production

### DIFF
--- a/web/lib/potato_mesh/application/federation.rb
+++ b/web/lib/potato_mesh/application/federation.rb
@@ -15,9 +15,24 @@
 module PotatoMesh
   module App
     module Federation
+      # Resolve the canonical domain for the running instance.
+      #
+      # @return [String, nil] sanitized instance domain or nil outside production.
+      # @raise [RuntimeError] when the domain cannot be determined in production.
       def self_instance_domain
         sanitized = sanitize_instance_domain(app_constant(:INSTANCE_DOMAIN))
         return sanitized if sanitized
+
+        unless production_environment?
+          debug_log(
+            "INSTANCE_DOMAIN unavailable; skipping self instance domain",
+            context: "federation.instances",
+            app_env: string_or_nil(ENV["APP_ENV"]),
+            rack_env: string_or_nil(ENV["RACK_ENV"]),
+            source: app_constant(:INSTANCE_DOMAIN_SOURCE),
+          )
+          return nil
+        end
 
         raise "INSTANCE_DOMAIN could not be determined"
       end

--- a/web/lib/potato_mesh/application/helpers.rb
+++ b/web/lib/potato_mesh/application/helpers.rb
@@ -334,6 +334,16 @@ module PotatoMesh
         ENV["RACK_ENV"] == "test"
       end
 
+      # Determine whether the application is running in a production environment.
+      #
+      # @return [Boolean] true when APP_ENV or RACK_ENV resolves to "production".
+      def production_environment?
+        app_env = string_or_nil(ENV["APP_ENV"])&.downcase
+        rack_env = string_or_nil(ENV["RACK_ENV"])&.downcase
+
+        app_env == "production" || rack_env == "production"
+      end
+
       # Determine whether federation features should be active.
       #
       # @return [Boolean] true when federation configuration allows it.


### PR DESCRIPTION
## Summary
- allow the federation helper to return a nil instance domain when the app is not running in production and emit structured diagnostics
- add a reusable helper for detecting production environments via APP_ENV/RACK_ENV
- cover the non-production behaviour with new self_instance_domain specs
