### PR TITLE
Add chat log entries for telemetry and topology broadcasts

### DIFF
--- a/web/public/assets/js/app/__tests__/chat-log-entry-renderer.test.js
+++ b/web/public/assets/js/app/__tests__/chat-log-entry-renderer.test.js
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2025 l5yth
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createBroadcastLogEntryElement, EVENT_LABELS, __test__ } from '../chat-log-entry-renderer.js';
+import { createDomEnvironment } from './dom-environment.js';
+
+const { selectBadgeSource, resolveFrequency } = __test__;
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+test('createBroadcastLogEntryElement renders telemetry entry with frequency', () => {
+  const env = createDomEnvironment();
+  const logEntry = {
+    ts: 1_000_000,
+    kind: 'telemetry',
+    node: { short_name: 'TLM', role: 'CLIENT', long_name: 'Telemetry Node' },
+    entry: { lora_freq: 915.0 }
+  };
+  const element = createBroadcastLogEntryElement({
+    document: env.document,
+    logEntry,
+    renderShortHtml: short => `<span class="short">${short ?? '?'}</span>`,
+    extractChatMessageMetadata: source => ({ frequency: source?.lora_freq ?? source?.frequency ?? null }),
+    formatNodeAnnouncementPrefix: ({ timestamp, frequency }) => `[${timestamp}][${frequency}]`,
+    escapeHtml,
+    formatTime: () => '12:00:00'
+  });
+  assert.ok(element);
+  assert.equal(element.className, 'chat-entry-event chat-entry-telemetry');
+  assert.equal(element.innerHTML, `[12:00:00][915] <span class="short">TLM</span> ${EVENT_LABELS.telemetry}`);
+  env.cleanup();
+});
+
+test('createBroadcastLogEntryElement falls back to node metadata for frequency', () => {
+  const env = createDomEnvironment();
+  const logEntry = {
+    ts: 1_000_100,
+    kind: 'position',
+    node: { short_name: 'POS', role: 'CLIENT', long_name: 'Position Node', frequency: '433' },
+    entry: {}
+  };
+  const element = createBroadcastLogEntryElement({
+    document: env.document,
+    logEntry,
+    renderShortHtml: short => `<span>${short ?? '?'}</span>`,
+    extractChatMessageMetadata: source => ({ frequency: source?.frequency ?? null }),
+    formatNodeAnnouncementPrefix: ({ timestamp, frequency }) => `[${timestamp}][${frequency}]`,
+    escapeHtml,
+    formatTime: () => '00:00:00'
+  });
+  assert.ok(element);
+  assert.equal(element.innerHTML, `[00:00:00][433] <span>POS</span> ${EVENT_LABELS.position}`);
+  env.cleanup();
+});
+
+test('createBroadcastLogEntryElement returns null for unsupported kinds', () => {
+  const env = createDomEnvironment();
+  const element = createBroadcastLogEntryElement({
+    document: env.document,
+    logEntry: { ts: 0, kind: 'unknown', entry: {} },
+    renderShortHtml: () => '',
+    extractChatMessageMetadata: () => ({}),
+    formatNodeAnnouncementPrefix: () => '',
+    escapeHtml,
+    formatTime: () => ''
+  });
+  assert.equal(element, null);
+  env.cleanup();
+});
+
+test('selectBadgeSource prefers node details but falls back to entry', () => {
+  const node = { short_name: 'NODE', role: 'CLIENT', long_name: 'Mesh Node' };
+  const entry = { short_name: 'PACK', role: 'REPEATER', long_name: 'Packet Source' };
+  const fromNode = selectBadgeSource({ node, entry });
+  assert.equal(fromNode.shortName, 'NODE');
+  const fromEntry = selectBadgeSource({ node: null, entry });
+  assert.equal(fromEntry.role, 'REPEATER');
+});
+
+test('resolveFrequency extracts first available frequency', () => {
+  const logEntry = {
+    entry: { frequency: '915' },
+    node: { frequency: '433' }
+  };
+  const freq = resolveFrequency({
+    logEntry,
+    extractChatMessageMetadata: source => ({ frequency: source.frequency ?? null })
+  });
+  assert.equal(freq, '915');
+});

--- a/web/public/assets/js/app/chat-log-entry-renderer.js
+++ b/web/public/assets/js/app/chat-log-entry-renderer.js
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2025 l5yth
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Human-readable labels describing mesh broadcast events rendered within the
+ * chat log.
+ *
+ * @type {Record<'telemetry' | 'position' | 'neighbor', string>}
+ */
+export const EVENT_LABELS = {
+  telemetry: 'broadcasted telemetry',
+  position: 'broadcasted position info',
+  neighbor: 'broadcasted neighbor info'
+};
+
+/**
+ * Construct a DOM node representing a broadcast event entry within the chat
+ * panel.
+ *
+ * @param {{
+ *   document: Document,
+ *   logEntry: {
+ *     ts: number,
+ *     kind: 'telemetry' | 'position' | 'neighbor',
+ *     node?: ?Object,
+ *     entry: Object
+ *   },
+ *   renderShortHtml: Function,
+ *   extractChatMessageMetadata: Function,
+ *   formatNodeAnnouncementPrefix: Function,
+ *   escapeHtml: Function,
+ *   formatTime: Function
+ * }} params Rendering dependencies and log entry metadata.
+ * @returns {?HTMLElement} Constructed element or ``null`` when rendering is not
+ *   possible.
+ */
+export function createBroadcastLogEntryElement({
+  document,
+  logEntry,
+  renderShortHtml,
+  extractChatMessageMetadata,
+  formatNodeAnnouncementPrefix,
+  escapeHtml,
+  formatTime
+}) {
+  if (!document || !logEntry || typeof logEntry !== 'object') {
+    return null;
+  }
+  const label = EVENT_LABELS[logEntry.kind];
+  if (!label) {
+    return null;
+  }
+  const container = document.createElement('div');
+  container.className = `chat-entry-event chat-entry-${logEntry.kind}`;
+
+  const tsSeconds = Number.isFinite(logEntry.ts) ? logEntry.ts : null;
+  const tsString = tsSeconds != null ? formatTime(new Date(tsSeconds * 1000)) : '--:--:--';
+
+  const badgeSource = selectBadgeSource(logEntry);
+  const shortHtml = renderShortHtml(
+    badgeSource.shortName,
+    badgeSource.role,
+    badgeSource.longName,
+    badgeSource.nodePayload
+  );
+
+  const frequency = resolveFrequency({ logEntry, extractChatMessageMetadata });
+  const prefix = formatNodeAnnouncementPrefix({
+    timestamp: escapeHtml(tsString),
+    frequency: frequency ? escapeHtml(frequency) : ''
+  });
+
+  container.innerHTML = `${prefix} ${shortHtml} ${escapeHtml(label)}`;
+  return container;
+}
+
+/**
+ * Derive the metadata required to render a short-name badge for the log entry.
+ *
+ * @param {{ logEntry: Object }} ctx Wrapper containing the log entry.
+ * @returns {{
+ *   shortName: ?string,
+ *   role: ?string,
+ *   longName: ?string,
+ *   nodePayload: ?Object
+ * }} Badge rendering metadata.
+ */
+function selectBadgeSource(logEntry) {
+  const nodeCandidate = logEntry.node && typeof logEntry.node === 'object' ? logEntry.node : null;
+  const entryCandidate = logEntry.entry && typeof logEntry.entry === 'object' ? logEntry.entry : null;
+  const source = nodeCandidate || entryCandidate || {};
+  const shortName = source.short_name ?? source.shortName ?? null;
+  const role = source.role ?? null;
+  const longName = source.long_name ?? source.longName ?? '';
+  return {
+    shortName,
+    role,
+    longName,
+    nodePayload: source
+  };
+}
+
+/**
+ * Determine the most relevant frequency value for the broadcast entry.
+ *
+ * @param {{
+ *   logEntry: Object,
+ *   extractChatMessageMetadata: Function
+ * }} params Frequency derivation dependencies.
+ * @returns {?string} Frequency string when discovered.
+ */
+function resolveFrequency({ logEntry, extractChatMessageMetadata }) {
+  const candidates = [logEntry.entry, logEntry.node];
+  for (const candidate of candidates) {
+    if (!candidate || typeof candidate !== 'object') {
+      continue;
+    }
+    const metadata = extractChatMessageMetadata(candidate);
+    if (metadata && metadata.frequency) {
+      return metadata.frequency;
+    }
+  }
+  return null;
+}
+
+export const __test__ = {
+  selectBadgeSource,
+  resolveFrequency
+};


### PR DESCRIPTION
## Summary
- include telemetry, position, and neighbor packets when building chat log entries
- render broadcast activity in the chat panel using a dedicated log entry component
- cover new behaviour with focused unit tests for the tab model and log renderer

## Testing
- npm test
- pytest
- bundle exec rspec
- black .
- rufo .

------
https://chatgpt.com/codex/tasks/task_e_6904a0d43e68832b890937673f7b083a