### PR TITLE
Ensure chat history fetches full message limit

### DIFF
--- a/web/public/assets/js/app/__tests__/message-limit.test.js
+++ b/web/public/assets/js/app/__tests__/message-limit.test.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2025-26 l5yth & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { MESSAGE_LIMIT, normaliseMessageLimit } from '../message-limit.js';
+
+test('normaliseMessageLimit defaults to the message limit for invalid input', () => {
+  assert.equal(normaliseMessageLimit(undefined), MESSAGE_LIMIT);
+  assert.equal(normaliseMessageLimit(null), MESSAGE_LIMIT);
+  assert.equal(normaliseMessageLimit(''), MESSAGE_LIMIT);
+  assert.equal(normaliseMessageLimit('abc'), MESSAGE_LIMIT);
+  assert.equal(normaliseMessageLimit(-100), MESSAGE_LIMIT);
+  assert.equal(normaliseMessageLimit(0), MESSAGE_LIMIT);
+  assert.equal(normaliseMessageLimit(Number.POSITIVE_INFINITY), MESSAGE_LIMIT);
+});
+
+test('normaliseMessageLimit clamps numeric input to the upper bound', () => {
+  assert.equal(normaliseMessageLimit(MESSAGE_LIMIT + 1), MESSAGE_LIMIT);
+  assert.equal(normaliseMessageLimit(MESSAGE_LIMIT * 2), MESSAGE_LIMIT);
+});
+
+test('normaliseMessageLimit accepts positive finite values', () => {
+  assert.equal(normaliseMessageLimit(250), 250);
+  assert.equal(normaliseMessageLimit('750'), 750);
+  assert.equal(normaliseMessageLimit(42.9), 42);
+});

--- a/web/public/assets/js/app/message-limit.js
+++ b/web/public/assets/js/app/message-limit.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2025-26 l5yth & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Maximum number of chat messages that the API can return in a single request.
+ * @type {number}
+ */
+export const MESSAGE_LIMIT = 1000;
+
+/**
+ * Normalise a candidate limit for the messages API to remain within supported bounds.
+ *
+ * The API clamps responses to {@link MESSAGE_LIMIT}, so this helper ensures the
+ * frontend always requests an allowed value while defaulting to the upper bound
+ * when callers omit or provide invalid data.
+ *
+ * @param {*} limit Candidate limit value supplied by the caller.
+ * @returns {number} Safe, positive limit capped at {@link MESSAGE_LIMIT}.
+ */
+export function normaliseMessageLimit(limit) {
+  const parsed = Number.parseFloat(limit);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return MESSAGE_LIMIT;
+  }
+  const floored = Math.floor(parsed);
+  if (floored <= 0) {
+    return MESSAGE_LIMIT;
+  }
+  return Math.min(floored, MESSAGE_LIMIT);
+}


### PR DESCRIPTION
## Summary
- add a dedicated message limit helper so the frontend always requests the API maximum
- update the dashboard refresh to request the full 1000 messages and reuse the shared limit constant
- cover the new limit normalisation logic with node:test unit coverage

## Testing
- rufo .
- black .
- pytest
- bundle exec rspec
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69139375a488832bbd927815227d347a)