### PR TITLE
Add encrypted filter to messages API

### DIFF
--- a/web/lib/potato_mesh/application/routes/api.rb
+++ b/web/lib/potato_mesh/application/routes/api.rb
@@ -75,7 +75,8 @@ module PotatoMesh
           app.get "/api/messages" do
             content_type :json
             limit = [params["limit"]&.to_i || 200, 1000].min
-            query_messages(limit).to_json
+            include_encrypted = coerce_boolean(params["encrypted"]) || false
+            query_messages(limit, include_encrypted: include_encrypted).to_json
           end
 
           app.get "/api/messages/:id" do
@@ -83,7 +84,8 @@ module PotatoMesh
             node_ref = string_or_nil(params["id"])
             halt 400, { error: "missing node id" }.to_json unless node_ref
             limit = [params["limit"]&.to_i || 200, 1000].min
-            query_messages(limit, node_ref: node_ref).to_json
+            include_encrypted = coerce_boolean(params["encrypted"]) || false
+            query_messages(limit, node_ref: node_ref, include_encrypted: include_encrypted).to_json
           end
 
           app.get "/api/positions" do


### PR DESCRIPTION
## Summary
- add an encrypted query flag to the GET /api/messages endpoints and keep encrypted payloads disabled by default
- update the message query to suppress encrypted rows unless the flag is enabled
- extend the API specs to cover the new filtering behaviour and canonical message assertions

## Testing
- pytest
- bundle exec rspec
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69146a5eb984832ba422d68e90bf9396)