### PR TITLE
Include encrypted chat log refresh

### DIFF
--- a/web/public/assets/js/app/__tests__/chat-message-merge.test.js
+++ b/web/public/assets/js/app/__tests__/chat-message-merge.test.js
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2025-26 l5yth & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { mergeChatMessages, __test__ } from '../chat-message-merge.js';
+
+const { computeMessageIdentity, appendUniqueMessage, selectFirstTruthy } = __test__;
+
+test('mergeChatMessages returns a cloned array when encrypted feed is empty', () => {
+  const base = [{ id: 1, text: 'hello' }];
+  const merged = mergeChatMessages(base, null);
+  assert.deepEqual(merged, base);
+  assert.notStrictEqual(merged, base);
+});
+
+test('mergeChatMessages appends encrypted-only entries and deduplicates by id', () => {
+  const base = [
+    { id: 1, text: 'hello' },
+    { id: 2, text: 'world' }
+  ];
+  const encrypted = [
+    { id: 2, encrypted: 'abc123' },
+    { id: 3, encrypted: 'xyz789' }
+  ];
+  const merged = mergeChatMessages(base, encrypted);
+  assert.equal(merged.length, 3);
+  assert.deepEqual(merged.map(entry => entry.id), [1, 2, 3]);
+  assert.strictEqual(merged[1], base[1]);
+  assert.strictEqual(merged[2], encrypted[1]);
+});
+
+test('mergeChatMessages deduplicates entries using fallback identity metadata', () => {
+  const base = [
+    { rx_time: 100, from_id: '!abcd', to_id: '!ef01', channel: 1, text: 'decrypted' }
+  ];
+  const encrypted = [
+    { rx_time: 100, from_id: '!abcd', to_id: '!ef01', channel: 1, encrypted: 'secret' }
+  ];
+  const merged = mergeChatMessages(base, encrypted);
+  assert.equal(merged.length, 1);
+  assert.strictEqual(merged[0], base[0]);
+});
+
+test('computeMessageIdentity resolves identifiers and handles invalid input', () => {
+  assert.equal(computeMessageIdentity(null), null);
+  assert.equal(computeMessageIdentity(undefined), null);
+  assert.equal(computeMessageIdentity('invalid'), null);
+  assert.equal(computeMessageIdentity({}), null);
+  assert.equal(computeMessageIdentity({ id: ' 42 ' }), 'id:42');
+  assert.equal(
+    computeMessageIdentity({ rx_time: 8, from_id: '!aaaa', to_id: '!bbbb', channel: 5 }),
+    'tuple:8|!aaaa|!bbbb|5|||'
+  );
+});
+
+test('appendUniqueMessage ignores invalid containers and respects identity registry', () => {
+  const seen = new Set();
+  const bucket = [];
+  appendUniqueMessage(null, bucket, seen);
+  appendUniqueMessage({ id: 1 }, bucket, {});
+  appendUniqueMessage({ id: 1 }, null, seen);
+  appendUniqueMessage({ id: 1 }, bucket, seen);
+  appendUniqueMessage({ id: 1 }, bucket, seen);
+  appendUniqueMessage({}, bucket, seen);
+  assert.equal(bucket.length, 2);
+  assert.equal(seen.has('id:1'), true);
+  assert.deepEqual(bucket[1], {});
+});
+
+test('selectFirstTruthy handles non-array inputs and returns the first non-null value', () => {
+  assert.equal(selectFirstTruthy(null), null);
+  assert.equal(selectFirstTruthy(undefined), null);
+  assert.equal(selectFirstTruthy('value'), null);
+  assert.equal(selectFirstTruthy([]), null);
+  assert.equal(selectFirstTruthy([null, undefined, 'first']), 'first');
+});

--- a/web/public/assets/js/app/chat-message-merge.js
+++ b/web/public/assets/js/app/chat-message-merge.js
@@ -1,0 +1,173 @@
+/*
+ * Copyright © 2025-26 l5yth & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Resolve the most stable identity available for a message entry.
+ *
+ * The identifier prioritises the explicit {@link message.id} property and
+ * falls back to a composite signature assembled from the timestamp and node
+ * addressing metadata.
+ *
+ * @param {object|null|undefined} message Message payload emitted by the API.
+ * @returns {string|null} Canonical identity token or {@code null} when the
+ * identifier cannot be derived.
+ */
+function computeMessageIdentity(message) {
+  if (!message || typeof message !== 'object') {
+    return null;
+  }
+
+  const candidateId = selectFirstTruthy([
+    message.id,
+    message.message_id,
+    message.messageId,
+    message.packet_id,
+    message.packetId
+  ]);
+  if (candidateId != null) {
+    const trimmed = String(candidateId).trim();
+    if (trimmed.length > 0) {
+      return `id:${trimmed}`;
+    }
+  }
+
+  const rxTime = selectFirstTruthy([
+    message.rx_time,
+    message.rxTime,
+    message.rx_timestamp,
+    message.rxTimestamp
+  ]);
+  const fromId = selectFirstTruthy([
+    message.from_id,
+    message.fromId,
+    message.node_id,
+    message.nodeId
+  ]);
+  const toId = selectFirstTruthy([
+    message.to_id,
+    message.toId
+  ]);
+  const channel = selectFirstTruthy([
+    message.channel,
+    message.channel_index,
+    message.channelIndex
+  ]);
+  const portnum = selectFirstTruthy([
+    message.portnum,
+    message.portNum
+  ]);
+  const replyId = selectFirstTruthy([
+    message.reply_id,
+    message.replyId
+  ]);
+  const emoji = selectFirstTruthy([
+    message.emoji
+  ]);
+
+  const signatureParts = [rxTime, fromId, toId, channel, portnum, replyId, emoji]
+    .map(value => (value == null ? '' : String(value).trim()));
+  const hasSignature = signatureParts.some(part => part.length > 0);
+  if (!hasSignature) {
+    return null;
+  }
+
+  return `tuple:${signatureParts.join('|')}`;
+}
+
+/**
+ * Append a message to the target collection if it has not been registered yet.
+ *
+ * @param {object|null|undefined} message Candidate message payload.
+ * @param {Array<object>} target Aggregated output collection.
+ * @param {Set<string>} seen Identity registry used for de-duplication.
+ * @returns {void}
+ */
+function appendUniqueMessage(message, target, seen) {
+  if (!message || typeof message !== 'object') {
+    return;
+  }
+  if (!Array.isArray(target) || !(seen instanceof Set)) {
+    return;
+  }
+
+  const identity = computeMessageIdentity(message);
+  if (identity && seen.has(identity)) {
+    return;
+  }
+
+  if (identity) {
+    seen.add(identity);
+  }
+  target.push(message);
+}
+
+/**
+ * Select the first candidate value that is neither {@code null} nor
+ * {@code undefined}.
+ *
+ * @param {Array<*>} candidates Potential values ordered by priority.
+ * @returns {*} First usable value or {@code null} when no candidates match.
+ */
+function selectFirstTruthy(candidates) {
+  if (!Array.isArray(candidates)) {
+    return null;
+  }
+  for (const candidate of candidates) {
+    if (candidate != null) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+/**
+ * Merge decrypted and encrypted chat message responses into a unified list.
+ *
+ * The resulting array preserves the order of the primary message feed while
+ * appending encrypted-only entries that were absent from the base query. Any
+ * overlapping packets are de-duplicated using their message identifiers.
+ *
+ * @param {Array<object>|null|undefined} normalMessages Primary message feed
+ * retrieved without encrypted payloads.
+ * @param {Array<object>|null|undefined} encryptedMessages Supplemental feed
+ * retrieved with encrypted payloads enabled.
+ * @returns {Array<object>} Stable collection containing each message exactly
+ * once.
+ */
+export function mergeChatMessages(normalMessages, encryptedMessages) {
+  const safeNormal = Array.isArray(normalMessages) ? normalMessages : [];
+  const safeEncrypted = Array.isArray(encryptedMessages) ? encryptedMessages : [];
+
+  if (safeEncrypted.length === 0) {
+    return safeNormal.slice();
+  }
+
+  const seen = new Set();
+  const merged = [];
+  for (const message of safeNormal) {
+    appendUniqueMessage(message, merged, seen);
+  }
+  for (const message of safeEncrypted) {
+    appendUniqueMessage(message, merged, seen);
+  }
+  return merged;
+}
+
+export const __test__ = {
+  computeMessageIdentity,
+  appendUniqueMessage,
+  selectFirstTruthy
+};

--- a/web/public/assets/js/app/main.js
+++ b/web/public/assets/js/app/main.js
@@ -44,6 +44,7 @@ import { renderChatTabs } from './chat-tabs.js';
 import { formatPositionHighlights, formatTelemetryHighlights } from './chat-log-highlights.js';
 import { filterChatModel, normaliseChatFilterQuery } from './chat-search.js';
 import { buildMessageBody, buildMessageIndex, resolveReplyPrefix } from './message-replies.js';
+import { mergeChatMessages } from './chat-message-merge.js';
 
 /**
  * Entry point for the interactive dashboard. Wires up event listeners,
@@ -3720,9 +3721,7 @@ let messagesById = new Map();
       mergeTelemetryIntoNodes(nodes, telemetryEntries);
       allNodes = nodes;
       rebuildNodeIndex(allNodes);
-      const normalMessages = Array.isArray(messages) ? messages : [];
-      const encryptedLogMessages = Array.isArray(encryptedMessages) ? encryptedMessages : [];
-      const combinedMessages = normalMessages.concat(encryptedLogMessages);
+      const combinedMessages = mergeChatMessages(messages, encryptedMessages);
       const chatMessages = await messageNodeHydrator.hydrate(combinedMessages, nodesById);
       allMessages = Array.isArray(chatMessages) ? chatMessages : [];
       allTelemetryEntries = Array.isArray(telemetryEntries) ? telemetryEntries : [];


### PR DESCRIPTION
## Summary
- request encrypted payloads when refreshing chat log messages while preserving standard queries for channel tabs
- merge encrypted responses into the hydrated chat data so log panels include secure activity in both the dashboard and chat view

## Testing
- black .
- rufo .
- pytest
- bundle exec rspec
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691473a2fbdc832b946289ce8d96cffe)