### PR TITLE
Add telemetry scatter charts to nodes page

### DIFF
--- a/web/public/assets/js/app/__tests__/nodes-charts.test.js
+++ b/web/public/assets/js/app/__tests__/nodes-charts.test.js
@@ -1,0 +1,220 @@
+/*
+ * Copyright © 2025-26 l5yth & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildMetricSeries,
+  computeAxisDomain,
+  createNodesChartsController,
+  extractMetricValue,
+  parseTimestampSeconds,
+  SEVEN_DAYS_SECONDS,
+  toFiniteNumber
+} from '../nodes-charts.js';
+
+/**
+ * Minimal element implementation used to exercise DOM interactions without
+ * relying on a browser environment.
+ */
+class FakeElement {
+  constructor(tagName) {
+    this.tagName = String(tagName).toUpperCase();
+    this.children = [];
+    this.attributes = new Map();
+    this.hidden = false;
+    this.textContent = '';
+    this.parentNode = null;
+    this.style = {
+      values: new Map(),
+      setProperty: (name, value) => {
+        this.style.values.set(name, value);
+      }
+    };
+  }
+
+  appendChild(child) {
+    this.children.push(child);
+    child.parentNode = this;
+    return child;
+  }
+
+  replaceChildren(...children) {
+    this.children = [];
+    for (const child of children) {
+      this.appendChild(child);
+    }
+  }
+
+  setAttribute(name, value) {
+    this.attributes.set(name, String(value));
+    if (name === 'data-role') {
+      this.dataset = this.dataset || {};
+      this.dataset.role = String(value);
+    }
+  }
+
+  getAttribute(name) {
+    return this.attributes.has(name) ? this.attributes.get(name) : null;
+  }
+}
+
+/**
+ * Minimal document abstraction that tracks elements by identifier.
+ */
+class FakeDocument {
+  constructor() {
+    this.elements = new Map();
+  }
+
+  registerElement(id, element) {
+    element.setAttribute('id', id);
+    this.elements.set(id, element);
+  }
+
+  getElementById(id) {
+    return this.elements.get(id) || null;
+  }
+
+  createElement(tagName) {
+    return new FakeElement(tagName);
+  }
+
+  createElementNS(_ns, tagName) {
+    return new FakeElement(tagName);
+  }
+}
+
+function buildTelemetryEntry(overrides = {}) {
+  return {
+    rx_time: overrides.rx_time ?? 1_000,
+    battery_level: overrides.battery_level,
+    voltage: overrides.voltage,
+    channel_utilization: overrides.channel_utilization,
+    air_util_tx: overrides.air_util_tx,
+    temperature: overrides.temperature,
+    relative_humidity: overrides.relative_humidity,
+    barometric_pressure: overrides.barometric_pressure
+  };
+}
+
+function createChartContainer(document, id) {
+  const container = new FakeElement('article');
+  const plot = new FakeElement('div');
+  plot.setAttribute('data-role', 'plot');
+  const legend = new FakeElement('ul');
+  legend.setAttribute('data-role', 'legend');
+  const empty = new FakeElement('p');
+  empty.setAttribute('data-role', 'empty');
+  container.appendChild(legend);
+  container.appendChild(plot);
+  container.appendChild(empty);
+  document.registerElement(id, container);
+  return { container, plot, legend, empty };
+}
+
+function registerCharts(document) {
+  createChartContainer(document, 'nodesChartPower');
+  createChartContainer(document, 'nodesChartChannel');
+  createChartContainer(document, 'nodesChartEnvironment');
+  const root = new FakeElement('section');
+  document.registerElement('nodesCharts', root);
+}
+
+test('toFiniteNumber normalises diverse input', () => {
+  assert.equal(toFiniteNumber('42'), 42);
+  assert.equal(toFiniteNumber(5.5), 5.5);
+  assert.equal(toFiniteNumber(null), null);
+  assert.equal(toFiniteNumber('bad'), null);
+});
+
+test('parseTimestampSeconds prefers numeric values', () => {
+  const entry = { rx_time: 1234, telemetry_time: 2000 };
+  assert.equal(parseTimestampSeconds(entry), 1234);
+
+  const iso = new Date(5000 * 1000).toISOString();
+  assert.equal(parseTimestampSeconds({ rx_iso: iso }), 5000);
+  assert.equal(parseTimestampSeconds({}), null);
+});
+
+test('extractMetricValue inspects multiple fields', () => {
+  const entry = { battery_level: '90', batteryLevel: 20 };
+  assert.equal(extractMetricValue(entry, ['missing', 'batteryLevel']), 20);
+  assert.equal(extractMetricValue(entry, ['battery_level']), 90);
+  assert.equal(extractMetricValue({}, ['x']), null);
+});
+
+test('buildMetricSeries filters entries outside the time window', () => {
+  const now = 10_000;
+  const entries = [
+    { rx_time: now - 10, battery_level: 80 },
+    { rx_time: now - SEVEN_DAYS_SECONDS - 10, battery_level: 60 },
+    { rx_time: now - 5, battery_level: 90 }
+  ];
+  const window = { minTimestampSec: now - SEVEN_DAYS_SECONDS, maxTimestampSec: now };
+  const series = buildMetricSeries(entries, { id: 'battery', fields: ['battery_level'] }, window);
+  assert.deepEqual(series, [
+    { timestamp: now - 10, value: 80 },
+    { timestamp: now - 5, value: 90 }
+  ]);
+});
+
+test('computeAxisDomain expands based on data and defaults', () => {
+  const seriesList = [
+    { metric: { axis: 'left' }, points: [{ value: 10 }, { value: 20 }] },
+    { metric: { axis: 'right' }, points: [{ value: 5 }] }
+  ];
+  const leftConfig = { defaultDomain: [0, 30] };
+  const domain = computeAxisDomain(seriesList, leftConfig, 'left');
+  assert.ok(domain.min <= 0);
+  assert.ok(domain.max >= 30);
+});
+
+test('createNodesChartsController renders scatter plots and toggles empty state', () => {
+  const document = new FakeDocument();
+  registerCharts(document);
+  const controller = createNodesChartsController({ document, nowProvider: () => 10_000 * 1000 });
+  const powerPlot = document.getElementById('nodesChartPower').children[1];
+  const powerEmpty = document.getElementById('nodesChartPower').children[2];
+  const powerLegend = document.getElementById('nodesChartPower').children[0];
+
+  // Initially empty state is visible and plot hidden.
+  assert.equal(powerPlot.hidden, true);
+  assert.equal(powerEmpty.hidden, false);
+  assert.equal(powerLegend.children.length, 2);
+  const firstSwatch = powerLegend.children[0].children[0];
+  assert.equal(firstSwatch.style.values.get('--legend-color'), '#2f855a');
+
+  controller.update([
+    buildTelemetryEntry({ rx_time: 10_000 - 60, battery_level: 70, voltage: 3.7 }),
+    buildTelemetryEntry({ rx_time: 10_000 - 30, battery_level: 65, voltage: 3.8 })
+  ]);
+
+  assert.equal(powerPlot.hidden, false);
+  assert.equal(powerEmpty.hidden, true);
+  const svg = powerPlot.children[0];
+  assert.ok(svg, 'expected svg element to be rendered');
+  const seriesGroup = svg.children[2];
+  const circles = seriesGroup.children.filter(child => child.tagName === 'CIRCLE');
+  assert.equal(circles.length, 4, 'expected one circle per metric sample');
+});
+
+test('createNodesChartsController tolerates missing containers', () => {
+  const document = new FakeDocument();
+  const controller = createNodesChartsController({ document });
+  assert.doesNotThrow(() => controller.update([]));
+});

--- a/web/public/assets/js/app/main.js
+++ b/web/public/assets/js/app/main.js
@@ -47,6 +47,7 @@ import { renderChatTabs } from './chat-tabs.js';
 import { formatPositionHighlights, formatTelemetryHighlights } from './chat-log-highlights.js';
 import { filterChatModel, normaliseChatFilterQuery } from './chat-search.js';
 import { buildMessageBody, buildMessageIndex, resolveReplyPrefix } from './message-replies.js';
+import { createNodesChartsController } from './nodes-charts.js';
 
 /**
  * Entry point for the interactive dashboard. Wires up event listeners,
@@ -93,6 +94,10 @@ export function initializeApp(config) {
   const bodyClassList = document.body ? document.body.classList : null;
   const isDashboardView = bodyClassList ? bodyClassList.contains('view-dashboard') : false;
   const isChatView = bodyClassList ? bodyClassList.contains('view-chat') : false;
+  const isNodesView = bodyClassList ? bodyClassList.contains('view-nodes') : false;
+  const nodesChartsController = isNodesView
+    ? createNodesChartsController({ document, nowProvider: () => Date.now() })
+    : null;
   /**
    * Column sorter configuration for the node table.
    *
@@ -3778,6 +3783,9 @@ let messagesById = new Map();
       allTelemetryEntries = Array.isArray(telemetryEntries) ? telemetryEntries : [];
       allPositionEntries = Array.isArray(positions) ? positions : [];
       allNeighbors = Array.isArray(neighborTuples) ? neighborTuples : [];
+      if (nodesChartsController) {
+        nodesChartsController.update(allTelemetryEntries);
+      }
       applyFilter();
       if (statusEl) {
         statusEl.textContent = 'updated ' + new Date().toLocaleTimeString();

--- a/web/public/assets/js/app/nodes-charts.js
+++ b/web/public/assets/js/app/nodes-charts.js
@@ -1,0 +1,669 @@
+/*
+ * Copyright © 2025-26 l5yth & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+/** @type {number} */
+export const SEVEN_DAYS_SECONDS = 7 * 24 * 3600;
+
+/**
+ * Determine whether a value can be converted into a finite number.
+ *
+ * @param {*} value Raw candidate value.
+ * @returns {number|null} Parsed finite number or null when conversion fails.
+ */
+export function toFiniteNumber(value) {
+  if (value == null || value === '') {
+    return null;
+  }
+  const numeric = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+/**
+ * Resolve the best-effort timestamp for a telemetry entry.
+ *
+ * @param {Record<string, *>} entry Telemetry payload.
+ * @returns {number|null} Timestamp in seconds or null when not available.
+ */
+export function parseTimestampSeconds(entry) {
+  if (!entry || typeof entry !== 'object') {
+    return null;
+  }
+  const rxTime = toFiniteNumber(entry.rx_time ?? entry.rxTime);
+  if (rxTime != null) {
+    return rxTime;
+  }
+  const telemetryTime = toFiniteNumber(entry.telemetry_time ?? entry.telemetryTime);
+  if (telemetryTime != null) {
+    return telemetryTime;
+  }
+  const isoValue = entry.rx_iso ?? entry.rxIso ?? entry.telemetry_time_iso ?? entry.telemetryTimeIso;
+  if (typeof isoValue === 'string' && isoValue.length > 0) {
+    const parsed = Date.parse(isoValue);
+    if (Number.isFinite(parsed)) {
+      return Math.floor(parsed / 1000);
+    }
+  }
+  return null;
+}
+
+/**
+ * Extract a telemetry metric using the provided property names.
+ *
+ * @param {Record<string, *>} entry Telemetry payload.
+ * @param {Array<string>} fields Candidate property keys.
+ * @returns {number|null} Numeric value or null when not found.
+ */
+export function extractMetricValue(entry, fields) {
+  if (!entry || typeof entry !== 'object' || !Array.isArray(fields)) {
+    return null;
+  }
+  for (const field of fields) {
+    if (Object.prototype.hasOwnProperty.call(entry, field)) {
+      const value = toFiniteNumber(entry[field]);
+      if (value != null) {
+        return value;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Build a sorted series of telemetry samples for a metric.
+ *
+ * @param {Array<Record<string, *>>} entries Telemetry dataset.
+ * @param {{ id: string, fields: Array<string> }} metric Metric definition.
+ * @param {{ minTimestampSec: number, maxTimestampSec: number }} window Time window bounds.
+ * @returns {Array<{ timestamp: number, value: number }>} Sorted samples.
+ */
+export function buildMetricSeries(entries, metric, window) {
+  if (!Array.isArray(entries) || !metric || !Array.isArray(metric.fields)) {
+    return [];
+  }
+  const minTs = toFiniteNumber(window?.minTimestampSec);
+  const maxTs = toFiniteNumber(window?.maxTimestampSec);
+  const samples = [];
+  for (const entry of entries) {
+    const timestamp = parseTimestampSeconds(entry);
+    if (timestamp == null) {
+      continue;
+    }
+    if (minTs != null && timestamp < minTs) {
+      continue;
+    }
+    if (maxTs != null && timestamp > maxTs) {
+      continue;
+    }
+    const value = extractMetricValue(entry, metric.fields);
+    if (value == null) {
+      continue;
+    }
+    samples.push({ timestamp, value });
+  }
+  samples.sort((a, b) => a.timestamp - b.timestamp);
+  return samples;
+}
+
+/**
+ * Compute the visual domain for an axis based on active series.
+ *
+ * @param {Array<{ metric: { axis: 'left' | 'right' }, points: Array<{ value: number }> }>} seriesList Series collection.
+ * @param {{ defaultDomain?: [number, number], min?: number, max?: number, formatTick?: (value: number) => string }} axisConfig Axis configuration.
+ * @param {'left'|'right'} axisName Axis identifier.
+ * @returns {{ min: number, max: number }|null} Domain boundaries or null when unavailable.
+ */
+export function computeAxisDomain(seriesList, axisConfig, axisName) {
+  if (!axisConfig) {
+    return null;
+  }
+  const values = [];
+  for (const series of seriesList) {
+    if (!series || series.metric?.axis !== axisName) {
+      continue;
+    }
+    for (const point of series.points || []) {
+      if (point && typeof point.value === 'number' && Number.isFinite(point.value)) {
+        values.push(point.value);
+      }
+    }
+  }
+  let minValue = values.length ? Math.min(...values) : null;
+  let maxValue = values.length ? Math.max(...values) : null;
+  if (Array.isArray(axisConfig.defaultDomain) && axisConfig.defaultDomain.length === 2) {
+    const [defaultMin, defaultMax] = axisConfig.defaultDomain;
+    if (minValue == null || defaultMin < minValue) {
+      minValue = defaultMin;
+    }
+    if (maxValue == null || defaultMax > maxValue) {
+      maxValue = defaultMax;
+    }
+  }
+  if (axisConfig.min != null) {
+    minValue = minValue == null ? axisConfig.min : Math.min(minValue, axisConfig.min);
+  }
+  if (axisConfig.max != null) {
+    maxValue = maxValue == null ? axisConfig.max : Math.max(maxValue, axisConfig.max);
+  }
+  if (minValue == null || maxValue == null) {
+    return null;
+  }
+  if (minValue === maxValue) {
+    const delta = Math.abs(minValue) || 1;
+    minValue -= delta * 0.1;
+    maxValue += delta * 0.1;
+  } else {
+    const padding = Math.max((maxValue - minValue) * 0.05, 0.5);
+    minValue -= padding;
+    maxValue += padding;
+  }
+  return { min: minValue, max: maxValue };
+}
+
+/**
+ * Create an SVG element within the current document namespace.
+ *
+ * @param {Document} document Owner document instance.
+ * @param {string} tagName SVG element name.
+ * @returns {SVGElement} Newly created element.
+ */
+function createSvgElement(document, tagName) {
+  return document.createElementNS ? document.createElementNS(SVG_NS, tagName) : document.createElement(tagName);
+}
+
+/**
+ * Locate a descendant element annotated with the provided data-role attribute.
+ *
+ * @param {Element|null} root Search root element.
+ * @param {string} role Data role identifier.
+ * @returns {Element|null} Matching element or null when absent.
+ */
+function findElementByDataRole(root, role) {
+  if (!root || typeof role !== 'string' || !role.length) {
+    return null;
+  }
+  const queue = [root];
+  while (queue.length) {
+    const node = queue.shift();
+    if (!node) {
+      continue;
+    }
+    if (typeof node.getAttribute === 'function') {
+      const value = node.getAttribute('data-role');
+      if (value === role) {
+        return node;
+      }
+    }
+    const children = node.children ? Array.from(node.children) : [];
+    for (const child of children) {
+      queue.push(child);
+    }
+  }
+  return null;
+}
+
+/**
+ * Generate a linear sequence of ticks covering the provided domain.
+ *
+ * @param {number} min Minimum domain value.
+ * @param {number} max Maximum domain value.
+ * @param {number} count Desired tick count.
+ * @returns {Array<number>} Tick positions in ascending order.
+ */
+function generateLinearTicks(min, max, count) {
+  if (!Number.isFinite(min) || !Number.isFinite(max) || count <= 1) {
+    return [min];
+  }
+  const span = max - min;
+  if (span <= 0) {
+    return [min];
+  }
+  const step = span / (count - 1);
+  const ticks = [];
+  for (let index = 0; index < count; index += 1) {
+    ticks.push(min + step * index);
+  }
+  return ticks;
+}
+
+/**
+ * Format a timestamp for display on the x-axis.
+ *
+ * @param {number} timestamp Timestamp in seconds.
+ * @returns {string} Human friendly label.
+ */
+function formatTimeLabel(timestamp) {
+  if (!Number.isFinite(timestamp)) {
+    return '';
+  }
+  const date = new Date(timestamp * 1000);
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  return `${month}-${day} ${hours}:${minutes}`;
+}
+
+/**
+ * Create a legend entry for the supplied metric definition.
+ *
+ * @param {Document} document Owner document instance.
+ * @param {{ label: string, color: string }} metric Metric configuration.
+ * @returns {HTMLElement} Legend list item element.
+ */
+function buildLegendItem(document, metric) {
+  const item = document.createElement('li');
+  item.setAttribute('class', 'nodes-chart__legend-item');
+  const swatch = document.createElement('span');
+  swatch.setAttribute('class', 'nodes-chart__legend-swatch');
+  if (swatch.style && typeof swatch.style.setProperty === 'function') {
+    swatch.style.setProperty('--legend-color', metric.color);
+  } else {
+    swatch.setAttribute('data-color', metric.color);
+  }
+  const label = document.createElement('span');
+  label.textContent = metric.label;
+  item.appendChild(swatch);
+  item.appendChild(label);
+  return item;
+}
+
+/**
+ * Toggle the visibility of the plot and empty-state message.
+ *
+ * @param {Element|null} plot Plot container element.
+ * @param {Element|null} empty Empty-state element.
+ * @param {boolean} isEmpty Whether the chart lacks data.
+ * @returns {void}
+ */
+function setEmptyState(plot, empty, isEmpty) {
+  if (plot) {
+    if (typeof plot.hidden === 'boolean') {
+      plot.hidden = isEmpty;
+    }
+    if (typeof plot.setAttribute === 'function') {
+      plot.setAttribute('aria-hidden', isEmpty ? 'true' : 'false');
+    }
+  }
+  if (empty) {
+    if (typeof empty.hidden === 'boolean') {
+      empty.hidden = !isEmpty;
+    }
+    if (typeof empty.setAttribute === 'function') {
+      empty.setAttribute('aria-hidden', isEmpty ? 'false' : 'true');
+    }
+  }
+}
+
+/**
+ * Render the scatter chart using SVG primitives.
+ *
+ * @param {Document} document Owner document instance.
+ * @param {SVGElement} svg Target SVG element.
+ * @param {Array<{ metric: { axis: 'left'|'right', color: string }, points: Array<{ timestamp: number, value: number }> }>} seriesList Chart series collection.
+ * @param {{ defaultDomain?: [number, number], min?: number, max?: number, formatTick?: (value: number) => string, label?: string }} leftAxis Left axis configuration.
+ * @param {{ defaultDomain?: [number, number], min?: number, max?: number, formatTick?: (value: number) => string, label?: string }} rightAxis Right axis configuration.
+ * @param {number} nowSec Reference timestamp in seconds.
+ * @returns {void}
+ */
+function renderScatterPlot(document, svg, seriesList, leftAxis, rightAxis, nowSec) {
+  svg.replaceChildren();
+  const width = 800;
+  const height = 320;
+  const margin = { top: 24, right: 88, bottom: 48, left: 88 };
+  const innerWidth = width - margin.left - margin.right;
+  const innerHeight = height - margin.top - margin.bottom;
+  svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+  svg.setAttribute('class', 'nodes-chart__svg');
+
+  const windowStart = nowSec - SEVEN_DAYS_SECONDS;
+  const xDomain = { min: windowStart, max: nowSec };
+  const leftDomain = computeAxisDomain(seriesList, leftAxis, 'left');
+  const rightDomain = computeAxisDomain(seriesList, rightAxis, 'right');
+
+  const gridGroup = createSvgElement(document, 'g');
+  gridGroup.setAttribute('class', 'nodes-chart__grid');
+  const axesGroup = createSvgElement(document, 'g');
+  axesGroup.setAttribute('class', 'nodes-chart__axes');
+  const seriesGroup = createSvgElement(document, 'g');
+  seriesGroup.setAttribute('class', 'nodes-chart__series');
+
+  svg.appendChild(gridGroup);
+  svg.appendChild(axesGroup);
+  svg.appendChild(seriesGroup);
+
+  const scaleX = value => {
+    const span = xDomain.max - xDomain.min || 1;
+    return margin.left + ((value - xDomain.min) / span) * innerWidth;
+  };
+  const scaleYLeft = value => {
+    if (!leftDomain) {
+      return margin.top + innerHeight;
+    }
+    const span = leftDomain.max - leftDomain.min || 1;
+    return margin.top + innerHeight - ((value - leftDomain.min) / span) * innerHeight;
+  };
+  const scaleYRight = value => {
+    if (!rightDomain) {
+      return margin.top + innerHeight;
+    }
+    const span = rightDomain.max - rightDomain.min || 1;
+    return margin.top + innerHeight - ((value - rightDomain.min) / span) * innerHeight;
+  };
+
+  const axisBottom = margin.top + innerHeight;
+  const xAxisLine = createSvgElement(document, 'line');
+  xAxisLine.setAttribute('x1', String(margin.left));
+  xAxisLine.setAttribute('x2', String(margin.left + innerWidth));
+  xAxisLine.setAttribute('y1', String(axisBottom));
+  xAxisLine.setAttribute('y2', String(axisBottom));
+  axesGroup.appendChild(xAxisLine);
+
+  const xTicks = generateLinearTicks(xDomain.min, xDomain.max, 6);
+  for (const tick of xTicks) {
+    const x = scaleX(tick);
+    const tickLine = createSvgElement(document, 'line');
+    tickLine.setAttribute('x1', String(x));
+    tickLine.setAttribute('x2', String(x));
+    tickLine.setAttribute('y1', String(axisBottom));
+    tickLine.setAttribute('y2', String(axisBottom + 8));
+    axesGroup.appendChild(tickLine);
+
+    const label = createSvgElement(document, 'text');
+    label.setAttribute('class', 'nodes-chart__tick-label nodes-chart__tick-label--x');
+    label.setAttribute('text-anchor', 'middle');
+    label.setAttribute('x', String(x));
+    label.setAttribute('y', String(axisBottom + 22));
+    label.textContent = formatTimeLabel(tick);
+    axesGroup.appendChild(label);
+  }
+
+  if (leftDomain) {
+    const leftAxisLine = createSvgElement(document, 'line');
+    leftAxisLine.setAttribute('x1', String(margin.left));
+    leftAxisLine.setAttribute('x2', String(margin.left));
+    leftAxisLine.setAttribute('y1', String(margin.top));
+    leftAxisLine.setAttribute('y2', String(axisBottom));
+    axesGroup.appendChild(leftAxisLine);
+
+    const yTicks = generateLinearTicks(leftDomain.min, leftDomain.max, 6);
+    for (const tick of yTicks) {
+      const y = scaleYLeft(tick);
+      const grid = createSvgElement(document, 'line');
+      grid.setAttribute('class', 'nodes-chart__grid-line');
+      grid.setAttribute('x1', String(margin.left));
+      grid.setAttribute('x2', String(margin.left + innerWidth));
+      grid.setAttribute('y1', String(y));
+      grid.setAttribute('y2', String(y));
+      gridGroup.appendChild(grid);
+
+      const tickLabel = createSvgElement(document, 'text');
+      tickLabel.setAttribute('class', 'nodes-chart__tick-label nodes-chart__tick-label--y');
+      tickLabel.setAttribute('text-anchor', 'end');
+      tickLabel.setAttribute('x', String(margin.left - 8));
+      tickLabel.setAttribute('y', String(y + 4));
+      const formatter = leftAxis?.formatTick ?? (value => value.toFixed(0));
+      tickLabel.textContent = formatter(tick);
+      axesGroup.appendChild(tickLabel);
+    }
+
+    if (leftAxis?.label) {
+      const axisLabel = createSvgElement(document, 'text');
+      axisLabel.setAttribute('class', 'nodes-chart__axis-label nodes-chart__axis-label--left');
+      axisLabel.setAttribute('text-anchor', 'middle');
+      axisLabel.setAttribute('transform', `translate(${margin.left - 56} ${margin.top + innerHeight / 2}) rotate(-90)`);
+      axisLabel.textContent = leftAxis.label;
+      axesGroup.appendChild(axisLabel);
+    }
+  }
+
+  if (rightDomain) {
+    const rightAxisLine = createSvgElement(document, 'line');
+    const rightX = margin.left + innerWidth;
+    rightAxisLine.setAttribute('x1', String(rightX));
+    rightAxisLine.setAttribute('x2', String(rightX));
+    rightAxisLine.setAttribute('y1', String(margin.top));
+    rightAxisLine.setAttribute('y2', String(axisBottom));
+    axesGroup.appendChild(rightAxisLine);
+
+    const yTicks = generateLinearTicks(rightDomain.min, rightDomain.max, 6);
+    for (const tick of yTicks) {
+      const y = scaleYRight(tick);
+      const tickLabel = createSvgElement(document, 'text');
+      tickLabel.setAttribute('class', 'nodes-chart__tick-label nodes-chart__tick-label--y');
+      tickLabel.setAttribute('text-anchor', 'start');
+      tickLabel.setAttribute('x', String(rightX + 8));
+      tickLabel.setAttribute('y', String(y + 4));
+      const formatter = rightAxis?.formatTick ?? (value => value.toFixed(0));
+      tickLabel.textContent = formatter(tick);
+      axesGroup.appendChild(tickLabel);
+    }
+
+    if (rightAxis?.label) {
+      const axisLabel = createSvgElement(document, 'text');
+      axisLabel.setAttribute('class', 'nodes-chart__axis-label nodes-chart__axis-label--right');
+      axisLabel.setAttribute('text-anchor', 'middle');
+      axisLabel.setAttribute('transform', `translate(${rightX + 56} ${margin.top + innerHeight / 2}) rotate(90)`);
+      axisLabel.textContent = rightAxis.label;
+      axesGroup.appendChild(axisLabel);
+    }
+  }
+
+  for (const series of seriesList) {
+    const axis = series.metric.axis === 'right' ? 'right' : 'left';
+    const domain = axis === 'right' ? rightDomain : leftDomain;
+    if (!domain) {
+      continue;
+    }
+    for (const point of series.points) {
+      const circle = createSvgElement(document, 'circle');
+      circle.setAttribute('class', 'nodes-chart__point');
+      circle.setAttribute('cx', String(scaleX(point.timestamp)));
+      const y = axis === 'right' ? scaleYRight(point.value) : scaleYLeft(point.value);
+      circle.setAttribute('cy', String(y));
+      circle.setAttribute('r', '4');
+      circle.setAttribute('fill', series.metric.color);
+      const title = createSvgElement(document, 'title');
+      title.textContent = `${series.metric.label ?? series.metric.id}: ${point.value}`;
+      circle.appendChild(title);
+      seriesGroup.appendChild(circle);
+    }
+  }
+}
+
+/**
+ * Build a scatter chart controller responsible for rendering a single plot.
+ *
+ * @param {Document} document Owner document instance.
+ * @param {{ id: string, metrics: Array<Object>, leftAxis: Object, rightAxis: Object }} config Chart configuration.
+ * @returns {{ update: (entries: Array<Record<string, *>>, window: { minTimestampSec: number, maxTimestampSec: number }, nowSec: number) => void }|null}
+ *   Controller with an update method or null when the container is missing.
+ */
+function createScatterChart(document, config) {
+  const container = document.getElementById ? document.getElementById(config.id) : null;
+  if (!container) {
+    return null;
+  }
+  const plot = findElementByDataRole(container, 'plot');
+  const legend = findElementByDataRole(container, 'legend');
+  const empty = findElementByDataRole(container, 'empty');
+  const svg = createSvgElement(document, 'svg');
+  if (plot) {
+    plot.replaceChildren(svg);
+  }
+  if (legend) {
+    legend.replaceChildren();
+    for (const metric of config.metrics) {
+      legend.appendChild(buildLegendItem(document, metric));
+    }
+  }
+  setEmptyState(plot, empty, true);
+
+  return {
+    update(entries, window, nowSec) {
+      const seriesList = config.metrics.map(metric => ({
+        metric,
+        points: buildMetricSeries(entries, metric, window)
+      }));
+      const hasData = seriesList.some(series => series.points.length > 0);
+      if (!hasData) {
+        svg.replaceChildren();
+        setEmptyState(plot, empty, true);
+        return;
+      }
+      setEmptyState(plot, empty, false);
+      renderScatterPlot(document, svg, seriesList, config.leftAxis, config.rightAxis, nowSec);
+    }
+  };
+}
+
+/**
+ * Initialise scatter charts on the nodes page if the containers are available.
+ *
+ * @param {{ document: Document, nowProvider?: () => number }} options Runtime dependencies.
+ * @returns {{ update: (entries: Array<Record<string, *>>) => void }} Controller exposing an update hook.
+ */
+export function createNodesChartsController({ document, nowProvider = () => Date.now() }) {
+  const root = document && document.getElementById ? document.getElementById('nodesCharts') : null;
+  if (!root) {
+    return {
+      update() {}
+    };
+  }
+
+  const chartConfigs = [
+    {
+      id: 'nodesChartPower',
+      metrics: [
+        {
+          id: 'battery_level',
+          label: 'Battery level (%)',
+          color: '#2f855a',
+          axis: 'left',
+          fields: ['battery_level', 'batteryLevel']
+        },
+        {
+          id: 'voltage',
+          label: 'Voltage (V)',
+          color: '#d97706',
+          axis: 'right',
+          fields: ['voltage']
+        }
+      ],
+      leftAxis: {
+        label: 'Battery level (%)',
+        defaultDomain: [0, 100],
+        min: 0,
+        max: 100,
+        formatTick: value => `${Math.round(value)}%`
+      },
+      rightAxis: {
+        label: 'Voltage (V)',
+        defaultDomain: [3, 6],
+        formatTick: value => `${value.toFixed(2)}V`
+      }
+    },
+    {
+      id: 'nodesChartChannel',
+      metrics: [
+        {
+          id: 'channel_utilization',
+          label: 'Channel utilisation (%)',
+          color: '#3182ce',
+          axis: 'left',
+          fields: ['channel_utilization', 'channelUtilization']
+        },
+        {
+          id: 'air_util_tx',
+          label: 'Air util Tx (%)',
+          color: '#805ad5',
+          axis: 'right',
+          fields: ['air_util_tx', 'airUtilTx']
+        }
+      ],
+      leftAxis: {
+        label: 'Channel utilisation (%)',
+        defaultDomain: [0, 100],
+        min: 0,
+        max: 100,
+        formatTick: value => `${Math.round(value)}%`
+      },
+      rightAxis: {
+        label: 'Air util Tx (%)',
+        defaultDomain: [0, 100],
+        min: 0,
+        max: 100,
+        formatTick: value => `${Math.round(value)}%`
+      }
+    },
+    {
+      id: 'nodesChartEnvironment',
+      metrics: [
+        {
+          id: 'temperature',
+          label: 'Temperature (°C)',
+          color: '#e53e3e',
+          axis: 'left',
+          fields: ['temperature']
+        },
+        {
+          id: 'relative_humidity',
+          label: 'Humidity (%)',
+          color: '#38b2ac',
+          axis: 'left',
+          fields: ['relative_humidity', 'relativeHumidity']
+        },
+        {
+          id: 'barometric_pressure',
+          label: 'Pressure (hPa)',
+          color: '#dd6b20',
+          axis: 'right',
+          fields: ['barometric_pressure', 'barometricPressure']
+        }
+      ],
+      leftAxis: {
+        label: 'Temperature (°C) & Humidity (%)',
+        defaultDomain: [-20, 100],
+        formatTick: value => `${Math.round(value)}`
+      },
+      rightAxis: {
+        label: 'Pressure (hPa)',
+        defaultDomain: [900, 1100],
+        formatTick: value => `${Math.round(value)} hPa`
+      }
+    }
+  ];
+
+  const charts = chartConfigs
+    .map(config => createScatterChart(document, config))
+    .filter(controller => controller != null);
+
+  return {
+    update(entries) {
+      const safeEntries = Array.isArray(entries) ? entries : [];
+      const now = Number(nowProvider()) || Date.now();
+      const nowSec = Math.floor(now / 1000);
+      const window = {
+        minTimestampSec: nowSec - SEVEN_DAYS_SECONDS,
+        maxTimestampSec: nowSec
+      };
+      for (const chart of charts) {
+        chart.update(safeEntries, window, nowSec);
+      }
+    }
+  };
+}

--- a/web/public/assets/styles/base.css
+++ b/web/public/assets/styles/base.css
@@ -581,6 +581,128 @@ body.view-map .map-panel--full #map {
   width: 100%;
 }
 
+.nodes-charts {
+  display: grid;
+  gap: calc(var(--pad) * 1.25);
+  margin-bottom: calc(var(--pad) * 0.75);
+}
+
+.nodes-charts__title {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.nodes-chart {
+  padding: calc(var(--pad) * 0.75);
+  border-radius: 12px;
+  border: 1px solid var(--line);
+  background: var(--card);
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--pad) * 0.5);
+}
+
+.nodes-chart__header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.nodes-chart__chart-title {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.nodes-chart__description {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.nodes-chart__legend {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.nodes-chart__legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85rem;
+}
+
+.nodes-chart__legend-swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(0, 0, 0, 0.25);
+  background: var(--legend-color, currentColor);
+}
+
+body.dark .nodes-chart__legend-swatch {
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.nodes-chart__plot {
+  width: 100%;
+  overflow: hidden;
+}
+
+.nodes-chart__plot[hidden] {
+  display: none;
+}
+
+.nodes-chart__empty {
+  margin: 0;
+  color: var(--muted);
+  font-style: italic;
+}
+
+.nodes-chart__svg {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.nodes-chart__axes line,
+.nodes-chart__axes path {
+  stroke: var(--line);
+  stroke-width: 1;
+}
+
+.nodes-chart__tick-label {
+  fill: var(--muted);
+  font-size: 12px;
+}
+
+.nodes-chart__axis-label {
+  fill: var(--muted);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.nodes-chart__point {
+  stroke: none;
+  fill-opacity: 0.9;
+}
+
+.nodes-chart__point:hover {
+  fill-opacity: 1;
+}
+
+.nodes-chart__grid-line {
+  stroke: var(--line);
+  stroke-dasharray: 4 4;
+  stroke-width: 1;
+  opacity: 0.5;
+}
+
 .map-panel {
   position: relative;
   flex: 1 1 0%;

--- a/web/views/nodes.erb
+++ b/web/views/nodes.erb
@@ -14,5 +14,59 @@
   limitations under the License.
 -->
 <section class="full-screen-section full-screen-section--nodes">
+  <section
+    id="nodesCharts"
+    class="nodes-charts"
+    aria-labelledby="nodesChartsTitle"
+    role="region"
+  >
+    <h2 id="nodesChartsTitle" class="nodes-charts__title">Telemetry charts</h2>
+
+    <article class="nodes-chart" id="nodesChartPower">
+      <header class="nodes-chart__header">
+        <h3 class="nodes-chart__chart-title">Power</h3>
+        <p class="nodes-chart__description">Battery level and voltage readings across the last seven days.</p>
+        <ul class="nodes-chart__legend" data-role="legend" role="list"></ul>
+      </header>
+      <div
+        class="nodes-chart__plot"
+        data-role="plot"
+        role="img"
+        aria-label="Battery level and voltage measurements over the previous seven days"
+      ></div>
+      <p class="nodes-chart__empty" data-role="empty">No power telemetry recorded in the last seven days.</p>
+    </article>
+
+    <article class="nodes-chart" id="nodesChartChannel">
+      <header class="nodes-chart__header">
+        <h3 class="nodes-chart__chart-title">Channel utilisation</h3>
+        <p class="nodes-chart__description">Channel utilisation and air utilisation (Tx) for the last seven days.</p>
+        <ul class="nodes-chart__legend" data-role="legend" role="list"></ul>
+      </header>
+      <div
+        class="nodes-chart__plot"
+        data-role="plot"
+        role="img"
+        aria-label="Channel utilisation and air utilisation (Tx) across the previous seven days"
+      ></div>
+      <p class="nodes-chart__empty" data-role="empty">No channel telemetry recorded in the last seven days.</p>
+    </article>
+
+    <article class="nodes-chart" id="nodesChartEnvironment">
+      <header class="nodes-chart__header">
+        <h3 class="nodes-chart__chart-title">Environment</h3>
+        <p class="nodes-chart__description">Temperature, humidity, and pressure observations from the last seven days.</p>
+        <ul class="nodes-chart__legend" data-role="legend" role="list"></ul>
+      </header>
+      <div
+        class="nodes-chart__plot"
+        data-role="plot"
+        role="img"
+        aria-label="Temperature, humidity, and pressure observations over the previous seven days"
+      ></div>
+      <p class="nodes-chart__empty" data-role="empty">No environmental telemetry recorded in the last seven days.</p>
+    </article>
+  </section>
+
   <%= erb :"shared/_nodes_table", locals: { full_screen: true } %>
 </section>


### PR DESCRIPTION
## Summary
- add scatter-plot telemetry charts to the nodes full-screen view for power, channel, and environment data
- render dual-axis SVG charts with colour-coded points over the most recent seven days
- provide comprehensive unit tests and styling for the new chart controller

## Testing
- `npm test`
- `bundle exec rspec`
- `pytest`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69162bf04840832b8da28d90f3deb9cf)