### PR TITLE
Aggregate frontend snapshots across views

### DIFF
--- a/web/public/assets/js/app/__tests__/node-details.test.js
+++ b/web/public/assets/js/app/__tests__/node-details.test.js
@@ -45,7 +45,7 @@ function createResponse(status, body) {
 test('refreshNodeInformation merges telemetry metrics when the base node lacks them', async () => {
   const calls = [];
   const responses = new Map([
-    ['/api/nodes/!test', createResponse(200, {
+    ['/api/nodes/!test?limit=7', createResponse(200, {
       node_id: '!test',
       short_name: 'TST',
       battery_level: null,
@@ -53,14 +53,14 @@ test('refreshNodeInformation merges telemetry metrics when the base node lacks t
       modem_preset: 'MediumFast',
       lora_freq: '868.1',
     })],
-    ['/api/telemetry/!test?limit=1', createResponse(200, [{
+    ['/api/telemetry/!test?limit=7', createResponse(200, [{
       node_id: '!test',
       battery_level: 73.5,
       rx_time: 1_200,
       telemetry_time: 1_180,
       voltage: 4.1,
     }])],
-    ['/api/positions/!test?limit=1', createResponse(200, [{
+    ['/api/positions/!test?limit=7', createResponse(200, [{
       node_id: '!test',
       latitude: 52.5,
       longitude: 13.4,
@@ -115,12 +115,12 @@ test('refreshNodeInformation merges telemetry metrics when the base node lacks t
 
 test('refreshNodeInformation preserves fallback metrics when telemetry is unavailable', async () => {
   const responses = new Map([
-    ['/api/nodes/42', createResponse(200, {
+    ['/api/nodes/42?limit=7', createResponse(200, {
       node_id: '!num',
       short_name: 'NUM',
     })],
-    ['/api/telemetry/42?limit=1', createResponse(404, { error: 'not found' })],
-    ['/api/positions/42?limit=1', createResponse(404, { error: 'not found' })],
+    ['/api/telemetry/42?limit=7', createResponse(404, { error: 'not found' })],
+    ['/api/positions/42?limit=7', createResponse(404, { error: 'not found' })],
     ['/api/neighbors/42?limit=1000', createResponse(404, { error: 'not found' })],
   ]);
   const fetchImpl = async (url, options) => {
@@ -147,15 +147,15 @@ test('refreshNodeInformation requires a node identifier', async () => {
 
 test('refreshNodeInformation handles missing node records by falling back to telemetry data', async () => {
   const responses = new Map([
-    ['/api/nodes/!missing', createResponse(404, { error: 'not found' })],
-    ['/api/telemetry/!missing?limit=1', createResponse(200, [{
+    ['/api/nodes/!missing?limit=7', createResponse(404, { error: 'not found' })],
+    ['/api/telemetry/!missing?limit=7', createResponse(200, [{
       node_id: '!missing',
       node_num: 77,
       battery_level: 66,
       rx_time: 2_000,
       telemetry_time: 1_950,
     }])],
-    ['/api/positions/!missing?limit=1', createResponse(200, [{
+    ['/api/positions/!missing?limit=7', createResponse(200, [{
       node_id: '!missing',
       latitude: 1.23,
       longitude: 3.21,

--- a/web/public/assets/js/app/__tests__/snapshot-aggregator.test.js
+++ b/web/public/assets/js/app/__tests__/snapshot-aggregator.test.js
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2025-26 l5yth & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  SNAPSHOT_WINDOW,
+  aggregateSnapshots,
+  aggregateNodeSnapshots,
+  aggregateTelemetrySnapshots,
+  aggregatePositionSnapshots,
+  aggregateNeighborSnapshots,
+} from '../snapshot-aggregator.js';
+
+const SAMPLE_NODE_ID = '!node';
+
+function keyById(entry) {
+  return entry && typeof entry.id === 'string' ? entry.id : null;
+}
+
+test('aggregateSnapshots merges snapshots in chronological order', () => {
+  const snapshots = [
+    { id: 'alpha', metric: null, label: 'latest', ts: 30, ignored: Number.NaN },
+    { id: 'alpha', metric: 5, label: null, ts: 20 },
+    { id: 'alpha', metric: 1, legacy: 'keep', ts: 10 },
+  ];
+  const aggregated = aggregateSnapshots(snapshots, { keySelector: keyById, limit: 3 });
+  assert.equal(aggregated.length, 1);
+  const record = aggregated[0];
+  assert.equal(record.metric, 5);
+  assert.equal(record.label, 'latest');
+  assert.equal(record.legacy, 'keep');
+  assert.deepEqual(record.snapshots.map(s => s.ts), [10, 20, 30]);
+  assert.equal(record.latestSnapshot.ts, 30);
+  assert.equal(Object.prototype.propertyIsEnumerable.call(record, 'snapshots'), false);
+  assert.equal(Object.prototype.propertyIsEnumerable.call(record, 'latestSnapshot'), false);
+  assert.equal('ignored' in record, false);
+});
+
+test('aggregateSnapshots enforces key selectors and respects limits', () => {
+  assert.throws(() => aggregateSnapshots([{ id: 'noop' }], {}), /keySelector/);
+  const snapshots = [
+    { id: 'beta', value: 'newest', ts: 30 },
+    { id: 'beta', value: 'mid', ts: 20 },
+    { id: 'beta', value: 'oldest', ts: 10 },
+  ];
+  const aggregated = aggregateSnapshots(snapshots, { keySelector: keyById, limit: 2 });
+  assert.equal(aggregated[0].snapshots.length, 2);
+  assert.deepEqual(aggregated[0].snapshots.map(s => s.ts), [20, 30]);
+});
+
+test('aggregateNodeSnapshots reconciles identifiers and fills missing values', () => {
+  const entries = [
+    { nodeId: SAMPLE_NODE_ID, voltage: 4.2, battery_level: null, rx_time: 250 },
+    { node_id: SAMPLE_NODE_ID, node_num: 42, battery_level: 20, rx_time: 200 },
+    { node_num: 42, short_name: 'Legacy', battery_level: 15, rx_time: 100 },
+  ];
+  const aggregated = aggregateNodeSnapshots(entries, { limit: SNAPSHOT_WINDOW });
+  assert.equal(aggregated.length, 1);
+  const node = aggregated[0];
+  assert.equal(node.node_id, SAMPLE_NODE_ID);
+  assert.equal(node.node_num, 42);
+  assert.equal(node.short_name, 'Legacy');
+  assert.equal(node.battery_level, 20);
+  assert.equal(node.voltage, 4.2);
+  assert.equal(node.snapshots.length, 3);
+});
+
+test('aggregateTelemetrySnapshots and aggregatePositionSnapshots mirror node aggregation', () => {
+  const telemetryEntries = [
+    { node_id: SAMPLE_NODE_ID, node_num: 5, temperature: null, rx_time: 20 },
+    { node_num: 5, temperature: 21.5, humidity: 52, rx_time: 10 },
+  ];
+  const positionEntries = [
+    { node_id: SAMPLE_NODE_ID, node_num: 5, longitude: 13.4, rx_time: 25 },
+    { node_num: 5, latitude: 52.5, rx_time: 15 },
+  ];
+  const telemetryAggregated = aggregateTelemetrySnapshots(telemetryEntries, { limit: 3 });
+  const positionAggregated = aggregatePositionSnapshots(positionEntries, { limit: 3 });
+  assert.equal(telemetryAggregated.length, 1);
+  assert.equal(positionAggregated.length, 1);
+  assert.equal(telemetryAggregated[0].temperature, 21.5);
+  assert.equal(telemetryAggregated[0].humidity, 52);
+  assert.equal(positionAggregated[0].latitude, 52.5);
+  assert.equal(positionAggregated[0].longitude, 13.4);
+});
+
+test('aggregateNeighborSnapshots groups by node pairs', () => {
+  const neighborSnapshots = [
+    { node_id: '!src', node_num: 101, neighbor_id: '!dst', neighbor_num: 202, snr: null, rx_time: 180 },
+    { node_id: '!src', node_num: 101, neighbor_id: '!dst', neighbor_num: 202, snr: -5, rx_time: 150 },
+    { node_num: 101, neighbor_num: 202, snr: -11, rx_time: 100 },
+    null,
+  ];
+  const aggregated = aggregateNeighborSnapshots(neighborSnapshots, { limit: 5 });
+  assert.equal(aggregated.length, 1);
+  const connection = aggregated[0];
+  assert.equal(connection.node_id, '!src');
+  assert.equal(connection.neighbor_id, '!dst');
+  assert.equal(connection.snr, -5);
+  assert.equal(connection.snapshots.length, 3);
+});
+
+test('aggregateSnapshots returns an empty array when no entries are provided', () => {
+  assert.deepEqual(aggregateSnapshots(null, { keySelector: () => 'noop' }), []);
+  assert.deepEqual(aggregateNodeSnapshots([], {}), []);
+});

--- a/web/public/assets/js/app/snapshot-aggregator.js
+++ b/web/public/assets/js/app/snapshot-aggregator.js
@@ -1,0 +1,267 @@
+/*
+ * Copyright © 2025-26 l5yth & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Number of snapshots to merge for each entity when aggregating records.
+ *
+ * @type {number}
+ */
+export const SNAPSHOT_WINDOW = 7;
+
+/**
+ * Determine whether a candidate behaves like an object.
+ *
+ * @param {*} value Candidate value to inspect.
+ * @returns {boolean} ``true`` when the value is a non-null object.
+ */
+function isObject(value) {
+  return value != null && typeof value === 'object';
+}
+
+/**
+ * Convert a raw identifier into a trimmed canonical string.
+ *
+ * @param {*} value Raw identifier.
+ * @returns {string|null} Normalised identifier or ``null`` when blank.
+ */
+function normaliseId(value) {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? null : trimmed;
+}
+
+/**
+ * Convert a raw numeric identifier into a finite number.
+ *
+ * @param {*} value Raw numeric identifier.
+ * @returns {number|null} Finite number or ``null`` when coercion fails.
+ */
+function normaliseNum(value) {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (value == null || value === '') return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * Merge snapshot fields into the destination object, skipping ``null`` values.
+ *
+ * @param {Object} target Destination object mutated in-place.
+ * @param {Object} snapshot Snapshot payload merged into ``target``.
+ * @returns {void}
+ */
+function mergeSnapshotFields(target, snapshot) {
+  if (!isObject(target) || !isObject(snapshot)) return;
+  for (const key of Object.keys(snapshot)) {
+    const value = snapshot[key];
+    if (value == null) continue;
+    if (typeof value === 'number' && Number.isNaN(value)) continue;
+    target[key] = value;
+  }
+}
+
+/**
+ * Build a key resolver that keeps node identifiers and numeric references
+ * associated with a single aggregate key.
+ *
+ * @returns {(entry: Object) => string|null} Key resolver function.
+ */
+function createNodeKeyResolver() {
+  const byId = new Map();
+  const byNum = new Map();
+  return entry => {
+    if (!isObject(entry)) return null;
+    const nodeId = normaliseId(entry.node_id ?? entry.nodeId);
+    const nodeNum = normaliseNum(entry.node_num ?? entry.nodeNum ?? entry.num);
+    if (nodeId && byId.has(nodeId)) {
+      const key = byId.get(nodeId);
+      if (nodeNum != null && !byNum.has(nodeNum)) {
+        byNum.set(nodeNum, key);
+      }
+      return key;
+    }
+    if (nodeNum != null && byNum.has(nodeNum)) {
+      const key = byNum.get(nodeNum);
+      if (nodeId) byId.set(nodeId, key);
+      return key;
+    }
+    let key = null;
+    if (nodeId) {
+      key = `id:${nodeId}`;
+    } else if (nodeNum != null) {
+      key = `num:${nodeNum}`;
+    }
+    if (key) {
+      if (nodeId) byId.set(nodeId, key);
+      if (nodeNum != null) byNum.set(nodeNum, key);
+    }
+    return key;
+  };
+}
+
+/**
+ * Ensure a property is attached to the aggregate object without exposing it
+ * through enumeration.
+ *
+ * @param {Object} target Destination aggregate object.
+ * @param {string} key Property name to assign.
+ * @param {*} value Property value.
+ * @returns {void}
+ */
+function defineHiddenProperty(target, key, value) {
+  Object.defineProperty(target, key, {
+    value,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+}
+
+/**
+ * Aggregate a collection of snapshots by key, merging up to
+ * {@link SNAPSHOT_WINDOW} entries for each logical entity.
+ *
+ * The supplied ``keySelector`` determines which entries belong to the same
+ * aggregate. Snapshots are merged in chronological order (oldest to newest),
+ * allowing recent values to override stale ones while retaining older data for
+ * fields that may be absent in the latest packet.
+ *
+ * @template T
+ * @param {Array<Object>} entries Raw snapshot entries.
+ * @param {{
+ *   keySelector: (entry: Object) => string|null,
+ *   limit?: number,
+ *   merge?: (target: Object, snapshot: Object) => void,
+ *   baseFactory?: (snapshot: Object) => T
+ * }} options Aggregation behaviour overrides.
+ * @returns {Array<T>} Aggregated snapshots.
+ */
+export function aggregateSnapshots(entries, {
+  keySelector,
+  limit = SNAPSHOT_WINDOW,
+  merge = mergeSnapshotFields,
+  baseFactory = () => ({}),
+} = {}) {
+  if (typeof keySelector !== 'function') {
+    throw new TypeError('aggregateSnapshots requires a keySelector function');
+  }
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return [];
+  }
+  const groups = new Map();
+  const maxSnapshots = Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : SNAPSHOT_WINDOW;
+  for (const entry of entries) {
+    if (!isObject(entry)) continue;
+    const key = keySelector(entry);
+    if (!key) continue;
+    let group = groups.get(key);
+    if (!group) {
+      group = [];
+      groups.set(key, group);
+    }
+    if (group.length >= maxSnapshots) continue;
+    group.push(entry);
+  }
+  const aggregates = [];
+  for (const group of groups.values()) {
+    if (!Array.isArray(group) || group.length === 0) continue;
+    const baseSnapshot = group[group.length - 1];
+    const target = baseFactory(isObject(baseSnapshot) ? { ...baseSnapshot } : {});
+    const orderedSnapshots = [];
+    for (let idx = group.length - 1; idx >= 0; idx -= 1) {
+      const snapshot = group[idx];
+      if (!isObject(snapshot)) continue;
+      const clone = { ...snapshot };
+      orderedSnapshots.push(clone);
+      merge(target, clone);
+    }
+    defineHiddenProperty(target, 'snapshots', orderedSnapshots);
+    defineHiddenProperty(target, 'latestSnapshot', orderedSnapshots[orderedSnapshots.length - 1] ?? null);
+    aggregates.push(target);
+  }
+  return aggregates;
+}
+
+/**
+ * Aggregate node records into enriched snapshots keyed by identifier.
+ *
+ * @param {Array<Object>} entries Node records fetched from the API.
+ * @param {{ limit?: number }} [options] Aggregation options.
+ * @returns {Array<Object>} Aggregated node payloads.
+ */
+export function aggregateNodeSnapshots(entries, { limit = SNAPSHOT_WINDOW } = {}) {
+  const resolveKey = createNodeKeyResolver();
+  return aggregateSnapshots(entries, { keySelector: resolveKey, limit });
+}
+
+/**
+ * Aggregate telemetry packets for each node.
+ *
+ * @param {Array<Object>} entries Telemetry payloads.
+ * @param {{ limit?: number }} [options] Aggregation options.
+ * @returns {Array<Object>} Aggregated telemetry data.
+ */
+export function aggregateTelemetrySnapshots(entries, { limit = SNAPSHOT_WINDOW } = {}) {
+  const resolveKey = createNodeKeyResolver();
+  return aggregateSnapshots(entries, { keySelector: resolveKey, limit });
+}
+
+/**
+ * Aggregate position packets for each node.
+ *
+ * @param {Array<Object>} entries Position payloads.
+ * @param {{ limit?: number }} [options] Aggregation options.
+ * @returns {Array<Object>} Aggregated position data.
+ */
+export function aggregatePositionSnapshots(entries, { limit = SNAPSHOT_WINDOW } = {}) {
+  const resolveKey = createNodeKeyResolver();
+  return aggregateSnapshots(entries, { keySelector: resolveKey, limit });
+}
+
+/**
+ * Aggregate neighbour packets for each node pair.
+ *
+ * @param {Array<Object>} entries Neighbour payloads.
+ * @param {{ limit?: number }} [options] Aggregation options.
+ * @returns {Array<Object>} Aggregated neighbour data.
+ */
+export function aggregateNeighborSnapshots(entries, { limit = SNAPSHOT_WINDOW } = {}) {
+  const resolveSourceKey = createNodeKeyResolver();
+  const resolveNeighborKey = createNodeKeyResolver();
+  return aggregateSnapshots(entries, {
+    limit,
+    keySelector: entry => {
+      if (!isObject(entry)) return null;
+      const sourceKey = resolveSourceKey(entry);
+      const neighborId = entry.neighbor_id ?? entry.neighborId;
+      const neighborNum = entry.neighbor_num ?? entry.neighborNum;
+      const neighborKey = resolveNeighborKey({ node_id: neighborId, node_num: neighborNum });
+      if (!sourceKey || !neighborKey) return null;
+      return `${sourceKey}->${neighborKey}`;
+    },
+  });
+}
+
+export const __testUtils = {
+  isObject,
+  normaliseId,
+  normaliseNum,
+  mergeSnapshotFields,
+  createNodeKeyResolver,
+  defineHiddenProperty,
+};


### PR DESCRIPTION
## Summary
- add snapshot aggregation utilities to merge recent node, telemetry, position, and neighbor payloads
- expand dashboard and chat fetches to request larger history windows and merge aggregated results before rendering
- update node detail fetching logic and tests to consume the richer aggregated snapshots

## Testing
- npm test
- POTATO_LOG=info bundle exec rspec
- pytest
- black .
- rufo .

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69163c53cfc0832b9d6718e38c75c9aa)