### PR TITLE
Add armv6 and riscv64 docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,6 +48,8 @@ jobs:
           - { name: linux-amd64, platform: linux/amd64, label: "Linux x86_64" }
           - { name: linux-arm64, platform: linux/arm64, label: "Linux ARM64" }
           - { name: linux-armv7, platform: linux/arm/v7, label: "Linux ARMv7" }
+          - { name: linux-armv6, platform: linux/arm/v6, label: "Linux ARMv6" }
+          - { name: linux-riscv64, platform: linux/riscv64, label: "Linux RISC-V" }
 
     steps:
     - name: Checkout repository
@@ -55,6 +57,8 @@ jobs:
 
     - name: Set up QEMU emulation
       uses: docker/setup-qemu-action@v3
+      with:
+        platforms: arm,arm64,arm/v6,arm/v7,riscv64
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -187,6 +191,8 @@ jobs:
         echo "- \`${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-web-linux-amd64:latest\` - Linux x86_64" >> $GITHUB_STEP_SUMMARY
         echo "- \`${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-web-linux-arm64:latest\` - Linux ARM64" >> $GITHUB_STEP_SUMMARY
         echo "- \`${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-web-linux-armv7:latest\` - Linux ARMv7" >> $GITHUB_STEP_SUMMARY
+        echo "- \`${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-web-linux-armv6:latest\` - Linux ARMv6" >> $GITHUB_STEP_SUMMARY
+        echo "- \`${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-web-linux-riscv64:latest\` - Linux RISC-V" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
 
         # Ingestor images
@@ -194,5 +200,7 @@ jobs:
         echo "- \`${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-ingestor-linux-amd64:latest\` - Linux x86_64" >> $GITHUB_STEP_SUMMARY
         echo "- \`${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-ingestor-linux-arm64:latest\` - Linux ARM64" >> $GITHUB_STEP_SUMMARY
         echo "- \`${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-ingestor-linux-armv7:latest\` - Linux ARMv7" >> $GITHUB_STEP_SUMMARY
+        echo "- \`${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-ingestor-linux-armv6:latest\` - Linux ARMv6" >> $GITHUB_STEP_SUMMARY
+        echo "- \`${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-ingestor-linux-riscv64:latest\` - Linux RISC-V" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -13,15 +13,25 @@ will pull the latest release images for you.
 
 ## Images on GHCR
 
-| Service  | Image                                                                                                         |
-|----------|---------------------------------------------------------------------------------------------------------------|
-| Web UI   | `ghcr.io/l5yth/potato-mesh-web-linux-amd64:<tag>` (e.g. `latest`, `3.0`, or `v3.0`)                           |
-| Ingestor | `ghcr.io/l5yth/potato-mesh-ingestor-linux-amd64:<tag>` (e.g. `latest`, `3.0`, or `v3.0`)                      |
+| Service  | Image                                                                                                         | Architecture |
+|----------|---------------------------------------------------------------------------------------------------------------|--------------|
+| Web UI   | `ghcr.io/l5yth/potato-mesh-web-linux-amd64:<tag>` (e.g. `latest`, `3.0`, or `v3.0`)                           | Linux x86_64 |
+| Web UI   | `ghcr.io/l5yth/potato-mesh-web-linux-arm64:<tag>` (e.g. `latest`, `3.0`, or `v3.0`)                           | Linux ARM64  |
+| Web UI   | `ghcr.io/l5yth/potato-mesh-web-linux-armv7:<tag>` (e.g. `latest`, `3.0`, or `v3.0`)                           | Linux ARMv7  |
+| Web UI   | `ghcr.io/l5yth/potato-mesh-web-linux-armv6:<tag>` (e.g. `latest`, `3.0`, or `v3.0`)                           | Linux ARMv6  |
+| Web UI   | `ghcr.io/l5yth/potato-mesh-web-linux-riscv64:<tag>` (e.g. `latest`, `3.0`, or `v3.0`)                         | Linux RISC-V |
+| Ingestor | `ghcr.io/l5yth/potato-mesh-ingestor-linux-amd64:<tag>` (e.g. `latest`, `3.0`, or `v3.0`)                      | Linux x86_64 |
+| Ingestor | `ghcr.io/l5yth/potato-mesh-ingestor-linux-arm64:<tag>` (e.g. `latest`, `3.0`, or `v3.0`)                      | Linux ARM64  |
+| Ingestor | `ghcr.io/l5yth/potato-mesh-ingestor-linux-armv7:<tag>` (e.g. `latest`, `3.0`, or `v3.0`)                      | Linux ARMv7  |
+| Ingestor | `ghcr.io/l5yth/potato-mesh-ingestor-linux-armv6:<tag>` (e.g. `latest`, `3.0`, or `v3.0`)                      | Linux ARMv6  |
+| Ingestor | `ghcr.io/l5yth/potato-mesh-ingestor-linux-riscv64:<tag>` (e.g. `latest`, `3.0`, or `v3.0`)                    | Linux RISC-V |
 
 Images are published for every tagged release. Each build receives both semantic
 version tags (for example `3.0`) and a matching `v`-prefixed tag (for example
 `v3.0`). `latest` always points to the newest release, so pin one of the version
-tags when you need a specific build.
+tags when you need a specific build. Set `POTATOMESH_IMAGE_ARCH` in your Compose
+environment to switch between the published architectures (for example,
+`linux-armv6` for ARMv6 or `linux-riscv64` for RISC-V).
 
 ## Configure environment
 


### PR DESCRIPTION
## Summary
- extend the Docker workflow matrix to build and publish ARMv6 and RISC-V images alongside existing architectures
- ensure QEMU emulation installs support for the new targets and release summaries list every published variant
- document all available architecture-specific tags and Compose selection via `POTATOMESH_IMAGE_ARCH`
- ref #482 
