### PR TITLE
Handle reaction app packets without reply id

### DIFF
--- a/web/public/assets/js/app/__tests__/message-replies.test.js
+++ b/web/public/assets/js/app/__tests__/message-replies.test.js
@@ -118,3 +118,36 @@ test('buildMessageBody treats REACTION_APP packets without reply identifiers as 
 
   assert.equal(body, 'EMOJI(🚀)');
 });
+
+test('buildMessageBody renders reaction emoji from text when emoji field carries placeholder counts', () => {
+  const placeholderEmojiMessage = {
+    text: '💩',
+    emoji: '1',
+    reply_id: 98822809,
+    portnum: 'TEXT_MESSAGE_APP'
+  };
+
+  const body = buildMessageBody({
+    message: placeholderEmojiMessage,
+    escapeHtml: value => `ESC(${value})`,
+    renderEmojiHtml: value => `EMOJI(${value})`
+  });
+
+  assert.equal(body, 'EMOJI(💩)');
+});
+
+test('buildMessageBody appends reaction counts for REACTION_APP packets without reply identifiers', () => {
+  const countedReactionAppPacket = {
+    text: '2',
+    emoji: '🌶',
+    portnum: 'REACTION_APP'
+  };
+
+  const body = buildMessageBody({
+    message: countedReactionAppPacket,
+    escapeHtml: value => `ESC(${value})`,
+    renderEmojiHtml: value => `EMOJI(${value})`
+  });
+
+  assert.equal(body, 'EMOJI(🌶) ESC(×2)');
+});

--- a/web/public/assets/js/app/message-replies.js
+++ b/web/public/assets/js/app/message-replies.js
@@ -359,19 +359,32 @@ export function buildMessageBody({ message, escapeHtml, renderEmojiHtml }) {
     return '';
   }
 
-  const segments = [];
+ const segments = [];
   const reaction = isReactionMessage(message);
   const textSegment = resolveMessageTextSegment(message, reaction);
   const reactionCount = reaction && textSegment && /^×\d+$/.test(textSegment) ? textSegment : null;
-  if (textSegment && !reaction) {
+  const emoji = normaliseEmojiValue(message.emoji);
+  const emojiIsNumericPlaceholder = reaction && emoji && /^\d+$/.test(emoji);
+  let reactionEmoji = reaction && !emojiIsNumericPlaceholder ? emoji : null;
+
+  if (!reaction && textSegment) {
     segments.push(escapeHtml(textSegment));
   }
-  const emoji = normaliseEmojiValue(message.emoji);
-  if (emoji) {
+
+  if (reaction) {
+    if (!reactionEmoji && textSegment && !reactionCount) {
+      reactionEmoji = textSegment;
+    }
+    if (reactionEmoji) {
+      segments.push(renderEmojiHtml(reactionEmoji));
+    } else if (textSegment && !reactionCount) {
+      segments.push(escapeHtml(textSegment));
+    }
+    if (reactionCount) {
+      segments.push(escapeHtml(reactionCount));
+    }
+  } else if (emoji) {
     segments.push(renderEmojiHtml(emoji));
-  }
-  if (reactionCount) {
-    segments.push(escapeHtml(reactionCount));
   }
 
   if (segments.length === 0) {


### PR DESCRIPTION
## Summary
- ensure reaction payloads with `portnum` set to `REACTION_APP` are classified as reactions even without reply identifiers
- keep reaction placeholder text suppressed for reaction app packets
- extend message replies tests to cover reaction app packets lacking reply IDs
- fix #492 