### PR TITLE
add contact link to the instance data

### DIFF
--- a/data/instances.sql
+++ b/data/instances.sql
@@ -26,6 +26,7 @@ CREATE TABLE IF NOT EXISTS instances (
   longitude         REAL,
   last_update_time  INTEGER,
   is_private        BOOLEAN NOT NULL DEFAULT 0,
+  contact_link      TEXT,
   signature         TEXT
 );
 

--- a/web/lib/potato_mesh/application/database.rb
+++ b/web/lib/potato_mesh/application/database.rb
@@ -164,6 +164,11 @@ module PotatoMesh
           db.execute_batch(File.read(sql_file))
         end
 
+        instance_columns = db.execute("PRAGMA table_info(instances)").map { |row| row[1] }
+        unless instance_columns.include?("contact_link")
+          db.execute("ALTER TABLE instances ADD COLUMN contact_link TEXT")
+        end
+
         telemetry_tables =
           db.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='telemetry'").flatten
         if telemetry_tables.empty?

--- a/web/lib/potato_mesh/application/federation.rb
+++ b/web/lib/potato_mesh/application/federation.rb
@@ -73,6 +73,7 @@ module PotatoMesh
           longitude: PotatoMesh::Config.map_center_lon,
           last_update_time: last_update,
           is_private: private_mode?,
+          contact_link: sanitized_contact_link,
         }
       end
 
@@ -96,6 +97,7 @@ module PotatoMesh
           "longitude" => attributes[:longitude],
           "lastUpdateTime" => attributes[:last_update_time],
           "isPrivate" => attributes[:is_private],
+          "contactLink" => attributes[:contact_link],
           "signature" => signature,
         }
         payload.reject { |_, value| value.nil? }
@@ -450,6 +452,7 @@ module PotatoMesh
 
       def canonical_instance_payload(attributes)
         data = {}
+        data["contactLink"] = attributes[:contact_link] if attributes[:contact_link]
         data["id"] = attributes[:id] if attributes[:id]
         data["domain"] = attributes[:domain] if attributes[:domain]
         data["pubkey"] = attributes[:pubkey] if attributes[:pubkey]
@@ -611,6 +614,7 @@ module PotatoMesh
           longitude: coerce_float(payload["longitude"]),
           last_update_time: coerce_integer(payload["lastUpdateTime"]),
           is_private: private_flag,
+          contact_link: string_or_nil(payload["contactLink"]),
         }
 
         [attributes, signature, nil]
@@ -1055,8 +1059,8 @@ module PotatoMesh
         sql = <<~SQL
           INSERT INTO instances (
             id, domain, pubkey, name, version, channel, frequency,
-            latitude, longitude, last_update_time, is_private, signature
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            latitude, longitude, last_update_time, is_private, contact_link, signature
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
           ON CONFLICT(id) DO UPDATE SET
             domain=excluded.domain,
             pubkey=excluded.pubkey,
@@ -1068,6 +1072,7 @@ module PotatoMesh
             longitude=excluded.longitude,
             last_update_time=excluded.last_update_time,
             is_private=excluded.is_private,
+            contact_link=excluded.contact_link,
             signature=excluded.signature
         SQL
 
@@ -1083,6 +1088,7 @@ module PotatoMesh
           attributes[:longitude],
           attributes[:last_update_time],
           attributes[:is_private] ? 1 : 0,
+          attributes[:contact_link],
           signature,
         ]
 

--- a/web/lib/potato_mesh/application/instances.rb
+++ b/web/lib/potato_mesh/application/instances.rb
@@ -143,6 +143,7 @@ module PotatoMesh
           "longitude" => coerce_float(row["longitude"]),
           "lastUpdateTime" => last_update_time,
           "isPrivate" => private_flag,
+          "contactLink" => string_or_nil(row["contact_link"]),
           "signature" => signature,
         }
 
@@ -173,7 +174,7 @@ module PotatoMesh
         min_last_update_time = now - PotatoMesh::Config.week_seconds
         sql = <<~SQL
           SELECT id, domain, pubkey, name, version, channel, frequency,
-                 latitude, longitude, last_update_time, is_private, signature
+                 latitude, longitude, last_update_time, is_private, contact_link, signature
           FROM instances
           WHERE domain IS NOT NULL AND TRIM(domain) != ''
             AND pubkey IS NOT NULL AND TRIM(pubkey) != ''


### PR DESCRIPTION
This pull request introduces support for a new `contact_link` field in the `instances` table and throughout the federation and API layers. The main goal is to allow each instance to store and share a contact link, which can be used for administrative or support purposes. The changes ensure that this new field is handled correctly during database migrations, federation announcements, upserts, and API responses.

**Database schema and migration:**

* Added a new `contact_link` column to the `instances` table, including logic to automatically add the column if it does not exist during schema upgrades. [[1]](diffhunk://#diff-5e5495bf7d9f06ce6d1221fcefd6450d0eb4b5c6e18fbe630d65599f8e84b6b8R29) [[2]](diffhunk://#diff-af70a93b4a1dc3f157729cfe361c7245443e12ba715be420fb88f1ef214e1657R167-R171)

**Federation and instance data handling:**

* Updated federation logic to include `contact_link` in self instance attributes, federation announcement payloads, canonical payloads, and remote instance attribute extraction. [[1]]( diffhunk://#diff-ac437e7dd89a60986bbb0cd7043d8e389a550787a66c9887b6a888cdc8a4de3aR76) [[2]](diffhunk://#diff-ac437e7dd89a60986bbb0cd7043d8e389a550787a66c9887b6a888cdc8a4de3aR100) [[3]](diffhunk://#diff-ac437e7dd89a60986bbb0cd7043d8e389a550787a66c9887b6a888cdc8a4de3aR455) [[4]](diffhunk://#diff-ac437e7dd89a60986bbb0cd7043d8e389a550787a66c9887b6a888cdc8a4de3aR617)
* Modified the upsert logic for instances to handle the new `contact_link` field, ensuring it is inserted and updated correctly in the database. [[1]](diffhunk://#diff-ac437e7dd89a60986bbb0cd7043d8e389a550787a66c9887b6a888cdc8a4de3aL1058-R1063) [[2]](diffhunk://#diff-ac437e7dd89a60986bbb0cd7043d8e389a550787a66c9887b6a888cdc8a4de3aR1075) [[3]](diffhunk://#diff-ac437e7dd89a60986bbb0cd7043d8e389a550787a66c9887b6a888cdc8a4de3aR1091)

**API and normalization:**

* Updated instance normalization and API loading methods to include the `contact_link` in responses, making it available to API consumers. [[1]](diffhunk://#diff-bc2baaafc8fc36227622bce239a42d476b7667882a66eddd91c43238f27f511cR146) [[2]](diffhunk://#diff-bc2baaafc8fc36227622bce239a42d476b7667882a66eddd91c43238f27f511cL176-R177)