### PR TITLE
Normalize numeric node roles to canonical labels

### DIFF
--- a/web/public/assets/js/app/__tests__/node-snapshot-normalizer.test.js
+++ b/web/public/assets/js/app/__tests__/node-snapshot-normalizer.test.js
@@ -62,6 +62,16 @@ test('normalizeNodeCollection applies canonical forms to all nodes', () => {
   assert.equal(nodes[1].air_util_tx, 5.5);
 });
 
+test('normalizeNodeSnapshot maps numeric roles to canonical identifiers', () => {
+  const roleNode = { role: '12', node_id: '!role' };
+  const numberRoleNode = { role: 12, nodeId: '!number-role' };
+
+  normalizeNodeCollection([roleNode, numberRoleNode]);
+
+  assert.equal(roleNode.role, 'CLIENT_BASE');
+  assert.equal(numberRoleNode.role, 'CLIENT_BASE');
+});
+
 test('normaliser helpers coerce primitive values consistently', () => {
   assert.equal(normalizeNumber('42.1'), 42.1);
   assert.equal(normalizeNumber('not-a-number'), null);

--- a/web/public/assets/js/app/node-snapshot-normalizer.js
+++ b/web/public/assets/js/app/node-snapshot-normalizer.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { translateRoleId } from './role-helpers.js';
+
 /**
  * Determine whether the supplied value acts like an object instance.
  *
@@ -34,6 +36,18 @@ function normalizeString(value) {
   if (value == null) return null;
   const str = String(value).trim();
   return str.length === 0 ? null : str;
+}
+
+/**
+ * Convert a raw role value into a canonical identifier.
+ *
+ * @param {*} value Raw role candidate from the API or cached snapshots.
+ * @returns {string|null} Canonical role string or ``null`` when blank.
+ */
+function normalizeRole(value) {
+  if (value == null) return null;
+  const translated = translateRoleId(value);
+  return normalizeString(translated);
 }
 
 /**
@@ -61,7 +75,7 @@ const FIELD_ALIASES = Object.freeze([
   { keys: ['node_num', 'nodeNum', 'num'], normalise: normalizeNumber },
   { keys: ['short_name', 'shortName'], normalise: normalizeString },
   { keys: ['long_name', 'longName'], normalise: normalizeString },
-  { keys: ['role'], normalise: normalizeString },
+  { keys: ['role'], normalise: normalizeRole },
   { keys: ['hw_model', 'hwModel'], normalise: normalizeString },
   { keys: ['modem_preset', 'modemPreset'], normalise: normalizeString },
   { keys: ['lora_freq', 'loraFreq'], normalise: normalizeNumber },


### PR DESCRIPTION
## Summary
- normalizes node snapshot role aliases using the shared translator so numeric identifiers resolve to canonical names
- adds coverage proving numeric role payloads are mapped to CLIENT_BASE during normalization

## Testing
- black .
- bundle exec rufo .
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931e7341208832ba169291babbc46c6)