### PR TITLE
Support BLE UUID format for macOS Bluetooth devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,8 +202,9 @@ Run the script with `INSTANCE_DOMAIN` and `API_TOKEN` to keep updating
 node records and parsing new incoming messages. Enable debug output with `DEBUG=1`,
 specify the connection target with `CONNECTION` (default `/dev/ttyACM0`) or set it to
 an IP address (for example `192.168.1.20:4403`) to use the Meshtastic TCP
-interface. `CONNECTION` also accepts Bluetooth device addresses (e.g.,
-`ED:4D:9E:95:CF:60`) and the script attempts a BLE connection if available. To keep
+interface. `CONNECTION` also accepts Bluetooth device addresses in MAC format (e.g.,
+`ED:4D:9E:95:CF:60`) or UUID format for macOS (e.g., `C0AEA92F-045E-9B82-C9A6-A1FD822B3A9E`)
+and the script attempts a BLE connection if available. To keep
 ingestion limited, set `ALLOWED_CHANNELS` to a comma-separated whitelist (for
 example `ALLOWED_CHANNELS="Chat,Ops"`); packets on other channels are discarded.
 Use `HIDDEN_CHANNELS` to block specific channels from the web UI even when they

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -2640,6 +2640,62 @@ def test_parse_ble_target_rejects_invalid_values(mesh_module):
     assert mesh._parse_ble_target("zz:zz:zz:zz:zz:zz") is None
 
 
+def test_parse_ble_target_accepts_mac_addresses(mesh_module):
+    """Test that _parse_ble_target accepts valid MAC address format (Linux/Windows)."""
+    mesh = mesh_module
+
+    # Valid MAC addresses should be accepted and normalized to uppercase
+    assert mesh._parse_ble_target("ED:4D:9E:95:CF:60") == "ED:4D:9E:95:CF:60"
+    assert mesh._parse_ble_target("ed:4d:9e:95:cf:60") == "ED:4D:9E:95:CF:60"
+    assert mesh._parse_ble_target("AA:BB:CC:DD:EE:FF") == "AA:BB:CC:DD:EE:FF"
+    assert mesh._parse_ble_target("00:11:22:33:44:55") == "00:11:22:33:44:55"
+
+    # With whitespace
+    assert mesh._parse_ble_target("  ED:4D:9E:95:CF:60  ") == "ED:4D:9E:95:CF:60"
+
+    # Invalid MAC addresses should be rejected
+    assert mesh._parse_ble_target("ED:4D:9E:95:CF") is None  # Too short
+    assert mesh._parse_ble_target("ED:4D:9E:95:CF:60:AB") is None  # Too long
+    assert mesh._parse_ble_target("GG:HH:II:JJ:KK:LL") is None  # Invalid hex
+
+
+def test_parse_ble_target_accepts_uuids(mesh_module):
+    """Test that _parse_ble_target accepts valid UUID format (macOS)."""
+    mesh = mesh_module
+
+    # Valid UUIDs should be accepted and normalized to uppercase
+    assert (
+        mesh._parse_ble_target("C0AEA92F-045E-9B82-C9A6-A1FD822B3A9E")
+        == "C0AEA92F-045E-9B82-C9A6-A1FD822B3A9E"
+    )
+    assert (
+        mesh._parse_ble_target("c0aea92f-045e-9b82-c9a6-a1fd822b3a9e")
+        == "C0AEA92F-045E-9B82-C9A6-A1FD822B3A9E"
+    )
+    assert (
+        mesh._parse_ble_target("12345678-1234-5678-9ABC-DEF012345678")
+        == "12345678-1234-5678-9ABC-DEF012345678"
+    )
+
+    # With whitespace
+    assert (
+        mesh._parse_ble_target("  C0AEA92F-045E-9B82-C9A6-A1FD822B3A9E  ")
+        == "C0AEA92F-045E-9B82-C9A6-A1FD822B3A9E"
+    )
+
+    # Invalid UUIDs should be rejected
+    assert mesh._parse_ble_target("C0AEA92F-045E-9B82-C9A6") is None  # Too short
+    assert (
+        mesh._parse_ble_target("C0AEA92F-045E-9B82-C9A6-A1FD822B3A9E-EXTRA") is None
+    )  # Too long
+    assert (
+        mesh._parse_ble_target("GGGGGGGG-GGGG-GGGG-GGGG-GGGGGGGGGGGG") is None
+    )  # Invalid hex
+    assert (
+        mesh._parse_ble_target("C0AEA92F:045E:9B82:C9A6:A1FD822B3A9E") is None
+    )  # Wrong separator
+
+
 def test_parse_network_target_additional_cases(mesh_module):
     mesh = mesh_module
 


### PR DESCRIPTION
This pull request adds support for recognizing both MAC address and UUID formats for Bluetooth Low Energy (BLE) device addresses, improving cross-platform compatibility (notably for macOS users). It updates the regex validation, normalizes the accepted formats, enhances logging, and introduces comprehensive tests for both address types.

**BLE Address Format Support:**

* Updated the BLE address regular expression in `interfaces.py` to accept both MAC addresses (Linux/Windows) and UUIDs (macOS), allowing for broader compatibility.
* Improved the `_parse_ble_target` function to normalize and validate both MAC and UUID address formats, updating the docstring accordingly.
* Enhanced BLE interface creation to log the address type (MAC or UUID) for better debugging and clarity.
* Updated the documentation in `README.md` to clarify that `CONNECTION` can now accept BLE device addresses in both MAC and UUID formats.

**Testing Improvements:**

* Added new tests in `test_mesh.py` to verify that `_parse_ble_target` correctly accepts and normalizes valid MAC addresses and UUIDs, and properly rejects invalid formats.