### PR TITLE
web: decryption confidence scoring

### DIFF
--- a/data/messages.sql
+++ b/data/messages.sql
@@ -29,7 +29,9 @@ CREATE TABLE IF NOT EXISTS messages (
     modem_preset TEXT,
     channel_name TEXT,
     reply_id INTEGER,
-    emoji TEXT
+    emoji TEXT,
+    decrypted INTEGER NOT NULL DEFAULT 0,
+    decryption_confidence REAL
 );
 
 CREATE INDEX IF NOT EXISTS idx_messages_rx_time   ON messages(rx_time);

--- a/web/lib/potato_mesh/application/database.rb
+++ b/web/lib/potato_mesh/application/database.rb
@@ -150,6 +150,16 @@ module PotatoMesh
           message_columns << "emoji"
         end
 
+        unless message_columns.include?("decrypted")
+          db.execute("ALTER TABLE messages ADD COLUMN decrypted INTEGER NOT NULL DEFAULT 0")
+          message_columns << "decrypted"
+        end
+
+        unless message_columns.include?("decryption_confidence")
+          db.execute("ALTER TABLE messages ADD COLUMN decryption_confidence REAL")
+          message_columns << "decryption_confidence"
+        end
+
         reply_index_exists =
           db.get_first_value(
             "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_messages_reply_id'",

--- a/web/spec/app_spec.rb
+++ b/web/spec/app_spec.rb
@@ -4007,13 +4007,16 @@ RSpec.describe "Potato Mesh Sinatra app" do
         with_db(readonly: true) do |db|
           db.results_as_hash = true
           row = db.get_first_row(
-            "SELECT text, encrypted, channel_name FROM messages WHERE id = ?",
+            "SELECT text, encrypted, channel_name, decrypted, decryption_confidence FROM messages WHERE id = ?",
             [payload["packet_id"]],
           )
 
           expect(row["text"]).to eq("Nabend")
           expect(row["encrypted"]).to be_nil
           expect(row["channel_name"]).to eq("BerlinMesh")
+          expect(row["decrypted"]).to eq(1)
+          expect(row["decryption_confidence"]).to be > 0.0
+          expect(row["decryption_confidence"]).to be <= 1.0
         end
       ensure
         if previous_psk.nil?
@@ -4087,13 +4090,15 @@ RSpec.describe "Potato Mesh Sinatra app" do
         with_db(readonly: true) do |db|
           db.results_as_hash = true
           row = db.get_first_row(
-            "SELECT text, encrypted, portnum FROM messages WHERE id = ?",
+            "SELECT text, encrypted, portnum, decrypted, decryption_confidence FROM messages WHERE id = ?",
             [payload["packet_id"]],
           )
 
           expect(row["text"]).to be_nil
           expect(row["encrypted"]).to eq(encrypted_payload)
           expect(row["portnum"]).to be_nil
+          expect(row["decrypted"]).to eq(0)
+          expect(row["decryption_confidence"]).to be_nil
         end
       ensure
         if previous_psk.nil?

--- a/web/spec/database_spec.rb
+++ b/web/spec/database_spec.rb
@@ -166,6 +166,20 @@ RSpec.describe PotatoMesh::App::Database do
     expect(telemetry_columns).to include("rx_time", "battery_level")
   end
 
+  it "adds decryption metadata columns to existing messages tables" do
+    SQLite3::Database.new(PotatoMesh::Config.db_path) do |db|
+      db.execute("CREATE TABLE nodes(node_id TEXT)")
+      db.execute("CREATE TABLE messages(id INTEGER PRIMARY KEY)")
+    end
+
+    expect(column_names_for("messages")).not_to include("decrypted", "decryption_confidence")
+
+    harness_class.ensure_schema_upgrades
+
+    message_columns = column_names_for("messages")
+    expect(message_columns).to include("decrypted", "decryption_confidence")
+  end
+
   it "creates trace tables when absent" do
     SQLite3::Database.new(PotatoMesh::Config.db_path) do |db|
       db.execute("CREATE TABLE nodes(node_id TEXT)")


### PR DESCRIPTION
Added a decrypted flag and decryption_confidence value to the messages schema, wired decryption confidence scoring into the Meshtastic cipher, and propagated these fields through message ingestion and API queries. The web app now marks decrypted text messages as decrypted: true with a 0.0–1.0 confidence score and keeps the confidence field absent for non-decrypted rows.

- Schema updates in data/messages.sql plus migration support in web/lib/potato_mesh/application/database.rb.
- Confidence scoring and metadata in web/lib/potato_mesh/application/meshtastic/cipher.rb, then stored in web/lib/potato_mesh/application/data_processing.rb.
- API exposure and normalization in web/lib/potato_mesh/application/queries.rb.
- Tests updated in web/spec/meshtastic_cipher_spec.rb, web/spec/app_spec.rb, and web/spec/database_spec.rb.

