### PR TITLE
[meshcore] enh: surface meshcore role types

### DIFF
--- a/data/mesh_ingestor/providers/meshcore.py
+++ b/data/mesh_ingestor/providers/meshcore.py
@@ -71,6 +71,14 @@ _CONNECT_TIMEOUT_SECS: float = 30.0
 _DEFAULT_BAUDRATE: int = 115200
 """Default baud rate for MeshCore serial connections."""
 
+# MeshCore ``ADV_TYPE_*`` (``AdvertDataHelpers.h``) → ``user.role`` for POST /api/nodes.
+_MESHCORE_ADV_TYPE_ROLE: dict[int, str] = {
+    1: "COMPANION",
+    2: "REPEATER",
+    3: "ROOM_SERVER",
+    4: "SENSOR",
+}
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -118,6 +126,26 @@ def _meshcore_node_id(public_key_hex: str | None) -> str | None:
     return "!" + public_key_hex[:8].lower()
 
 
+def _meshcore_adv_type_to_role(adv_type: object) -> str | None:
+    """Map MeshCore ``ADV_TYPE_*`` (contact ``type`` / self ``adv_type``) to ingest role.
+
+    Values match MeshCore firmware ``AdvertDataHelpers.h`` (``ADV_TYPE_CHAT``,
+    ``ADV_TYPE_REPEATER``, …).  Role strings match the MeshCore palette keys
+    used by the web dashboard (``COMPANION``, ``REPEATER``, …).
+
+    Parameters:
+        adv_type: Raw type byte from meshcore_py (typically ``int`` 0–4).
+
+    Returns:
+        Uppercase role string, or ``None`` when the value is unknown or should
+        not override the web default (``ADV_TYPE_NONE`` / unrecognised).
+    """
+
+    if not isinstance(adv_type, int):
+        return None
+    return _MESHCORE_ADV_TYPE_ROLE.get(adv_type)
+
+
 def _pubkey_prefix_to_node_id(contacts: dict, pubkey_prefix: str) -> str | None:
     """Look up a canonical node ID by six-byte public-key prefix.
 
@@ -141,20 +169,22 @@ def _contact_to_node_dict(contact: dict) -> dict:
 
     Parameters:
         contact: Contact dict from the MeshCore library.  Expected keys
-            include ``public_key``, ``adv_name``, ``last_advert``,
-            ``adv_lat``, and ``adv_lon``.
+            include ``public_key``, ``type`` (``ADV_TYPE_*``), ``adv_name``,
+            ``last_advert``, ``adv_lat``, and ``adv_lon``.
 
     Returns:
         Node dict compatible with the ``POST /api/nodes`` payload format.
     """
     pub_key = contact.get("public_key", "")
     name = (contact.get("adv_name") or "").strip()
+    role = _meshcore_adv_type_to_role(contact.get("type"))
     node: dict = {
         "lastHeard": contact.get("last_advert"),
         "user": {
             "longName": name,
             "shortName": name[:4] if name else "",
             "publicKey": pub_key,
+            **({"role": role} if role is not None else {}),
         },
     }
     lat = contact.get("adv_lat")
@@ -169,19 +199,22 @@ def _self_info_to_node_dict(self_info: dict) -> dict:
 
     Parameters:
         self_info: Payload dict from the ``SELF_INFO`` event.  Expected keys
-            include ``name``, ``public_key``, ``adv_lat``, and ``adv_lon``.
+            include ``name``, ``public_key``, ``adv_type`` (``ADV_TYPE_*``),
+            ``adv_lat``, and ``adv_lon``.
 
     Returns:
         Node dict compatible with the ``POST /api/nodes`` payload format.
     """
     name = (self_info.get("name") or "").strip()
     pub_key = self_info.get("public_key", "")
+    role = _meshcore_adv_type_to_role(self_info.get("adv_type"))
     node: dict = {
         "lastHeard": int(time.time()),
         "user": {
             "longName": name,
             "shortName": name[:4] if name else "",
             "publicKey": pub_key,
+            **({"role": role} if role is not None else {}),
         },
     }
     lat = self_info.get("adv_lat")

--- a/tests/test_provider_unit.py
+++ b/tests/test_provider_unit.py
@@ -38,6 +38,7 @@ from data.mesh_ingestor.providers.meshcore import (  # noqa: E402 - path setup
     _derive_message_id,
     _make_connection,
     _make_event_handlers,
+    _meshcore_adv_type_to_role,
     _meshcore_node_id,
     _process_contact_update,
     _process_contacts,
@@ -562,6 +563,27 @@ def test_pubkey_prefix_returns_none_for_empty_contacts():
 
 
 # ---------------------------------------------------------------------------
+# _meshcore_adv_type_to_role
+# ---------------------------------------------------------------------------
+
+
+def test_meshcore_adv_type_to_role_maps_adv_types():
+    """Known ADV_TYPE_* integers map to dashboard role strings."""
+    assert _meshcore_adv_type_to_role(1) == "COMPANION"
+    assert _meshcore_adv_type_to_role(2) == "REPEATER"
+    assert _meshcore_adv_type_to_role(3) == "ROOM_SERVER"
+    assert _meshcore_adv_type_to_role(4) == "SENSOR"
+
+
+def test_meshcore_adv_type_to_role_none_for_unmapped():
+    """ADV_TYPE_NONE, unknown codes, and non-integers yield None."""
+    assert _meshcore_adv_type_to_role(0) is None
+    assert _meshcore_adv_type_to_role(99) is None
+    assert _meshcore_adv_type_to_role(None) is None
+    assert _meshcore_adv_type_to_role("1") is None
+
+
+# ---------------------------------------------------------------------------
 # _contact_to_node_dict
 # ---------------------------------------------------------------------------
 
@@ -578,6 +600,23 @@ def test_contact_to_node_dict_basic_fields():
     assert node["user"]["longName"] == "Alice"
     assert node["user"]["shortName"] == "Alic"
     assert node["user"]["publicKey"] == contact["public_key"]
+    assert "role" not in node["user"]
+
+
+def test_contact_to_node_dict_sets_role_from_type():
+    """Contact ``type`` must populate ``user.role`` when ADV_TYPE is mapped."""
+    base = {"public_key": "aabbccdd" + "00" * 28, "adv_name": "Rpt"}
+    assert _contact_to_node_dict({**base, "type": 2})["user"]["role"] == "REPEATER"
+
+
+def test_contact_to_node_dict_omits_role_for_adv_type_none():
+    """ADV_TYPE_NONE (0) must not set ``user.role``."""
+    contact = {
+        "public_key": "aabbccdd" + "00" * 28,
+        "adv_name": "X",
+        "type": 0,
+    }
+    assert "role" not in _contact_to_node_dict(contact)["user"]
 
 
 def test_contact_to_node_dict_includes_position_when_nonzero():
@@ -619,6 +658,19 @@ def test_self_info_to_node_dict_basic_fields():
     assert node["user"]["shortName"] == "MyNo"
     assert node["user"]["publicKey"] == "bb" * 32
     assert isinstance(node["lastHeard"], int)
+    assert "role" not in node["user"]
+
+
+def test_self_info_to_node_dict_sets_role_from_adv_type():
+    """SELF_INFO ``adv_type`` must populate ``user.role`` when mapped."""
+    self_info = {"name": "Srv", "public_key": "cc" * 32, "adv_type": 3}
+    assert _self_info_to_node_dict(self_info)["user"]["role"] == "ROOM_SERVER"
+
+
+def test_self_info_to_node_dict_omits_role_for_adv_type_none():
+    """adv_type 0 must not set ``user.role``."""
+    self_info = {"name": "N", "public_key": "dd" * 32, "adv_type": 0}
+    assert "role" not in _self_info_to_node_dict(self_info)["user"]
 
 
 def test_self_info_to_node_dict_includes_position():


### PR DESCRIPTION
This PR udpates the meshcore ingestor to use meshcore role names.

<img width="764" height="452" alt="image" src="https://github.com/user-attachments/assets/de8f0b47-f7c1-44b0-8318-fa9445de71cd" />
