### PR TITLE
chore: bump version to 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,46 @@
 
 # CHANGELOG
 
+## v0.6.2
+
+This is a service release of the radio mesh app-suite `potato-mesh` v0.6.2, focused on Meshcore-related fixes, federation accuracy, and bridge coverage. The Matrix bridge now understands Meshcore traffic, and several duplication and classification issues in the web app and ingestor have been tightened up.
+
+Demo: <https://potatomesh.net/>
+
+### Features
+* Matrix: enable meshcore by @l5yth in <https://github.com/l5yth/potato-mesh/pull/761>
+* Web: show colocated nodes by @l5yth in <https://github.com/l5yth/potato-mesh/pull/753>
+
+### Fixes
+* Web: fix emoji pattern render in short names by @l5yth in <https://github.com/l5yth/potato-mesh/pull/760>
+* Data: catch packet handler errors by @l5yth in <https://github.com/l5yth/potato-mesh/pull/759>
+* Web: fix meshcore message duplication with 120s dupe protection by @l5yth in <https://github.com/l5yth/potato-mesh/pull/758>
+* Web: fix node duplication through message synthetization by @l5yth in <https://github.com/l5yth/potato-mesh/pull/757>
+* Ingestor: deduplicate meshcore messages by @l5yth in <https://github.com/l5yth/potato-mesh/pull/752>
+* Fix reaction handling and classification by @l5yth in <https://github.com/l5yth/potato-mesh/pull/750>
+* Web: fix federation node counts by @l5yth in <https://github.com/l5yth/potato-mesh/pull/749>
+
+## v0.6.1
+
+This is a service release of the radio mesh app-suite `potato-mesh` v0.6.1, focused on Meshcore polish, federation resilience, and ingestor stability in the wake of the v0.6.0 multi-protocol release.
+
+Demo: <https://potatomesh.net/>
+
+### Features
+* Web: per protocol active node counts by @l5yth in <https://github.com/l5yth/potato-mesh/pull/735>
+* Web: optimize caching by @l5yth in <https://github.com/l5yth/potato-mesh/pull/744>
+* Data: better lora frequency handling for meshtastic by @l5yth in <https://github.com/l5yth/potato-mesh/pull/733>
+
+### Fixes
+* Web: fix meshcore node misclassification by @l5yth in <https://github.com/l5yth/potato-mesh/pull/748>
+* Web: fix federation resolver issue with multi addresses by @l5yth in <https://github.com/l5yth/potato-mesh/pull/743>
+* Web: restore refresh and protocol buttons by @l5yth in <https://github.com/l5yth/potato-mesh/pull/742>
+* Ingestor: fix serial connection failures by @l5yth in <https://github.com/l5yth/potato-mesh/pull/736>
+
+### Chores
+* Chore: bump version to 0.6.1 by @l5yth in <https://github.com/l5yth/potato-mesh/pull/726>
+* Build(deps): bump rand from 0.9.2 to 0.9.4 in /matrix by @dependabot in <https://github.com/l5yth/potato-mesh/pull/741>
+
 ## v0.6.0
 
 This is a service release of the radio mesh app-suite `potato-mesh` v0.6.0 which introduces new features and overhauls the user interface. The primary notable change is added support for multi-protocol along with an implementation of **Meshcore** in ingestor, web app, and frontend.

--- a/README.md
+++ b/README.md
@@ -300,9 +300,9 @@ docker pull ghcr.io/l5yth/potato-mesh-matrix-bridge-linux-arm64:latest
 docker pull ghcr.io/l5yth/potato-mesh-matrix-bridge-linux-armv7:latest
 
 # version-pinned examples
-docker pull ghcr.io/l5yth/potato-mesh-web-linux-amd64:v0.6.0
-docker pull ghcr.io/l5yth/potato-mesh-ingestor-linux-amd64:v0.6.0
-docker pull ghcr.io/l5yth/potato-mesh-matrix-bridge-linux-amd64:v0.6.0
+docker pull ghcr.io/l5yth/potato-mesh-web-linux-amd64:v0.6.2
+docker pull ghcr.io/l5yth/potato-mesh-ingestor-linux-amd64:v0.6.2
+docker pull ghcr.io/l5yth/potato-mesh-matrix-bridge-linux-amd64:v0.6.2
 ```
 
 Note: `latest` is only published for non-prerelease versions. Pre-release tags

--- a/app/ios/Flutter/AppFrameworkInfo.plist
+++ b/app/ios/Flutter/AppFrameworkInfo.plist
@@ -15,11 +15,11 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.6.1</string>
+  <string>0.6.2</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>
-  <string>0.6.1</string>
+  <string>0.6.2</string>
   <key>MinimumOSVersion</key>
   <string>14.0</string>
 </dict>

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -1,7 +1,7 @@
 name: potato_mesh_reader
 description: Meshtastic Reader — read-only view for PotatoMesh messages.
 publish_to: "none"
-version: 0.6.1
+version: 0.6.2
 
 environment:
   sdk: ">=3.4.0 <4.0.0"

--- a/data/__init__.py
+++ b/data/__init__.py
@@ -18,7 +18,7 @@ The ``data.mesh`` module exposes helpers for reading Meshtastic node and
 message information before forwarding it to the accompanying web application.
 """
 
-VERSION = "0.6.1"
+VERSION = "0.6.2"
 """Semantic version identifier shared with the dashboard and front-end."""
 
 __version__ = VERSION

--- a/matrix/Cargo.lock
+++ b/matrix/Cargo.lock
@@ -969,7 +969,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "potatomesh-matrix-bridge"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/matrix/Cargo.toml
+++ b/matrix/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "potatomesh-matrix-bridge"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 
 [dependencies]

--- a/web/lib/potato_mesh/config.rb
+++ b/web/lib/potato_mesh/config.rb
@@ -207,7 +207,7 @@ module PotatoMesh
     #
     # @return [String] semantic version identifier.
     def version_fallback
-      "0.6.1"
+      "0.6.2"
     end
 
     # Default refresh interval for frontend polling routines.

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "potato-mesh",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "type": "module",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Backfill v0.6.1 CHANGELOG entry (previously undocumented),
add v0.6.2 entry covering 9 commits since v0.6.1, and bump
the version string across data, web, matrix, and app along
with the README docker-pull examples.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
