### PR TITLE
data: move connected event to after ensure_contacts

### DIFF
--- a/data/mesh_ingestor/protocols/meshcore/_constants.py
+++ b/data/mesh_ingestor/protocols/meshcore/_constants.py
@@ -23,7 +23,17 @@ from __future__ import annotations
 import re
 
 _CONNECT_TIMEOUT_SECS: float = 30.0
-"""Seconds to wait for the MeshCore node to respond to the appstart handshake."""
+"""Seconds to wait for :class:`MeshcoreProvider.connect` to return.
+
+Bounds the whole startup sequence inside
+:func:`~data.mesh_ingestor.protocols.meshcore.runner._run_meshcore` up to and
+including the initial contact roster fetch: the appstart handshake
+(``mc.connect()``) **plus** the multiple serial round-trips performed by
+``mc.ensure_contacts()``.  The signal that unblocks the caller is intentionally
+deferred until contacts have been fetched so that the daemon's first
+``_try_send_snapshot()`` sees a populated ``iface._contacts`` dict
+(issue #788).
+"""
 
 _DEFAULT_BAUDRATE: int = 115200
 """Default baud rate for MeshCore serial connections."""

--- a/data/mesh_ingestor/protocols/meshcore/provider.py
+++ b/data/mesh_ingestor/protocols/meshcore/provider.py
@@ -79,7 +79,13 @@ class MeshcoreProvider:
 
         Raises:
             ConnectionError: When the node does not complete the handshake
-                within :data:`_CONNECT_TIMEOUT_SECS` seconds.
+                **and** the initial contact fetch
+                (``mc.ensure_contacts()``) within
+                :data:`_CONNECT_TIMEOUT_SECS` seconds.  Since issue #788, the
+                readiness signal is deferred until contacts have been fetched
+                so the daemon's first snapshot sees a populated contact list;
+                the timeout therefore bounds both steps rather than just the
+                appstart handshake.
         """
         target: str | None = active_candidate or config.CONNECTION
 

--- a/data/mesh_ingestor/protocols/meshcore/runner.py
+++ b/data/mesh_ingestor/protocols/meshcore/runner.py
@@ -113,7 +113,6 @@ async def _run_meshcore(
             )
 
         iface.isConnected = True
-        connected_event.set()
 
         try:
             await mc.ensure_contacts()
@@ -125,6 +124,11 @@ async def _run_meshcore(
                 always=True,
                 error=str(exc),
             )
+
+        # Signal readiness only after the initial contact roster has been
+        # fetched so the daemon's first ``_try_send_snapshot()`` observes a
+        # populated ``_contacts`` dict instead of an empty one (issue #788).
+        connected_event.set()
 
         try:
             await _ensure_channel_names(mc)

--- a/tests/test_provider_unit.py
+++ b/tests/test_provider_unit.py
@@ -15,12 +15,33 @@
 
 from __future__ import annotations
 
+import asyncio
 import sys
+import threading
+import time
 import types
 from contextlib import suppress
 from pathlib import Path
 
 import pytest
+
+
+async def _wait_for_threading_event(evt: threading.Event, *, timeout: float) -> bool:
+    """Yield to the asyncio loop until *evt* is set or *timeout* elapses.
+
+    Uses :func:`asyncio.sleep` so the background ``_run_meshcore`` task running
+    on the same event loop gets scheduling opportunities while the test waits.
+    Returns ``True`` when the event was set in time, ``False`` on timeout —
+    callers can assert on the return value to surface a clear failure rather
+    than a hand-tuned spin count.
+    """
+    deadline = time.monotonic() + timeout
+    while not evt.is_set():
+        if time.monotonic() >= deadline:
+            return False
+        await asyncio.sleep(0)
+    return True
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
@@ -3101,28 +3122,62 @@ def test_run_meshcore_connect_returns_none_raises(monkeypatch):
 
 
 def test_run_meshcore_ensure_contacts_failure_continues(monkeypatch):
-    """ensure_contacts() raising must log a warning but not abort the connection."""
-    import asyncio
+    """ensure_contacts() raising must log a warning but not abort the connection.
+
+    Also pins down the ordering established by issue #788: the
+    ``connected_event`` must still be signalled *after* the
+    ``ensure_contacts`` warning is logged, even on the failure path.  A
+    regression that moves ``connected_event.set()`` back inside the
+    ``try:`` block (so it fires before the ``await mc.ensure_contacts()``)
+    must fail here.
+    """
     import data.mesh_ingestor.protocols.meshcore as _mod
 
-    logged: list = []
-    monkeypatch.setattr(
-        _mod.config,
-        "_debug_log",
-        lambda *_a, severity=None, **_k: logged.append(severity),
-    )
+    logged_severities: list = []
+    warning_observed_event_state: list = []
+
+    # Build the holder upfront so the closure below can inspect it the
+    # moment the warning is logged — which happens *inside* the inner
+    # ``ensure_contacts`` except block in runner.py, before
+    # ``connected_event.set()``.
+    iface = _MeshcoreInterface(target=None)
+    connected_event = threading.Event()
+    error_holder: list = [None]
+
+    def _record_log(*args, severity=None, **_kwargs):
+        logged_severities.append(severity)
+        if (
+            severity == "warning"
+            and args
+            and "Failed to fetch initial contacts" in str(args[0])
+        ):
+            warning_observed_event_state.append(connected_event.is_set())
+
+    monkeypatch.setattr(_mod.config, "_debug_log", _record_log)
     fake_mod = _make_fake_meshcore_mod(fail_ensure_contacts=True)
     _patch_meshcore_mod(monkeypatch, _mod, fake_mod)
 
-    iface = _MeshcoreInterface(target=None)
+    async def _runner() -> None:
+        task = asyncio.create_task(
+            _mod._run_meshcore(iface, "/dev/ttyUSB0", connected_event, error_holder)
+        )
+        assert await _wait_for_threading_event(
+            connected_event, timeout=2.0
+        ), "connected_event must be signalled even when ensure_contacts fails"
+        assert iface._stop_event is not None
+        iface._stop_event.set()
+        await task
 
-    connected_event, error_holder = asyncio.run(
-        _run_until_connected(iface, "/dev/ttyUSB0", fake_mod, _mod)
-    )
+    asyncio.run(_runner())
 
     assert connected_event.is_set()
     assert error_holder[0] is None
-    assert "warning" in logged
+    assert "warning" in logged_severities
+    assert warning_observed_event_state == [False], (
+        "ensure_contacts warning must be logged before connected_event is "
+        "set (issue #788); observed states: "
+        f"{warning_observed_event_state!r}"
+    )
 
 
 def test_run_meshcore_signals_connected_only_after_ensure_contacts(monkeypatch):
@@ -3130,18 +3185,21 @@ def test_run_meshcore_signals_connected_only_after_ensure_contacts(monkeypatch):
 
     The MeshCore initial snapshot in :func:`daemon._try_send_snapshot` runs as
     soon as :func:`MeshcoreProvider.connect` returns, which itself returns as
-    soon as ``connected_event`` is set.  If ``connected_event`` is signalled
-    before ``ensure_contacts()`` finishes populating ``iface._contacts``, the
-    first snapshot is empty and ``state.initial_snapshot_sent`` is never set
-    to ``True`` (daemon.py:428), so known contacts never get upserted.
+    soon as ``connected_event`` is set.  If ``connected_event`` fires before
+    ``ensure_contacts()`` finishes populating ``iface._contacts``, the
+    daemon's first snapshot is empty, ``processed_any`` stays ``False``, and
+    ``state.initial_snapshot_sent`` is not flipped (daemon.py:428).  The
+    snapshot is retried on the next ``_loop_iteration`` pass, so the impact
+    is a ``SNAPSHOT_SECS`` delay before known contacts appear rather than a
+    permanent failure — but the dashboard is empty in the meantime, which
+    is what issue #788 reports.
 
     This test drives :func:`_run_meshcore` with a fake ``ensure_contacts``
-    that injects a contact into the interface, then records the contact
-    snapshot at the precise moment ``connected_event`` is observed.  The
-    snapshot must already contain the contact.
+    that injects a contact into the interface, then exercises
+    :meth:`MeshcoreProvider.node_snapshot_items` — the call the daemon
+    actually makes — at the precise moment ``connected_event`` is observed.
+    The snapshot must already contain the contact.
     """
-    import asyncio
-    import threading
     import data.mesh_ingestor.protocols.meshcore as _mod
 
     monkeypatch.setattr(_mod.config, "_debug_log", lambda *_a, **_k: None)
@@ -3157,30 +3215,29 @@ def test_run_meshcore_signals_connected_only_after_ensure_contacts(monkeypatch):
     fake_mod = _make_fake_meshcore_mod(on_ensure_contacts=_populate_contacts)
     _patch_meshcore_mod(monkeypatch, _mod, fake_mod)
 
+    connected_event = threading.Event()
+    error_holder: list = [None]
     snapshot_at_signal: list = []
 
     async def _runner() -> None:
-        connected_event = threading.Event()
-        error_holder: list = [None]
         task = asyncio.create_task(
             _mod._run_meshcore(iface, "/dev/ttyUSB0", connected_event, error_holder)
         )
-        # Spin until the runner signals readiness, then immediately capture
-        # the contact snapshot — this is the exact moment the daemon would
-        # call _try_send_snapshot() in production.
-        for _ in range(500):
-            await asyncio.sleep(0)
-            if connected_event.is_set():
-                snapshot_at_signal.extend(iface.contacts_snapshot())
-                break
+        assert await _wait_for_threading_event(connected_event, timeout=2.0), (
+            "connected_event was not signalled within the timeout — runner "
+            "may be deadlocked"
+        )
+        # Go through the full provider helper, not iface.contacts_snapshot()
+        # directly, so a future regression that drops contacts from
+        # node_snapshot_items() is also caught.
+        snapshot_at_signal.extend(MeshcoreProvider().node_snapshot_items(iface))
         assert iface._stop_event is not None
         iface._stop_event.set()
         await task
-        assert error_holder[0] is None
-        assert connected_event.is_set()
 
     asyncio.run(_runner())
 
+    assert error_holder[0] is None
     assert snapshot_at_signal, (
         "connected_event must not fire before ensure_contacts() populates "
         "iface._contacts (issue #788)"

--- a/tests/test_provider_unit.py
+++ b/tests/test_provider_unit.py
@@ -2826,6 +2826,7 @@ def _make_fake_meshcore_mod(
     fail_ensure_contacts: bool = False,
     disconnect_raises: bool = False,
     connect_stall_event=None,
+    on_ensure_contacts=None,
 ):
     """Build a minimal fake ``meshcore`` module for testing :func:`_run_meshcore`.
 
@@ -2838,6 +2839,10 @@ def _make_fake_meshcore_mod(
             the ``finally`` exception-suppression path.
         connect_stall_event: Optional :class:`asyncio.Event`; when set,
             ``connect()`` awaits it (never completes unless the event is set).
+        on_ensure_contacts: Optional zero-argument callable invoked inside
+            ``mc.ensure_contacts()`` (after the ``fail_ensure_contacts`` check)
+            so tests can populate ``iface._contacts`` mid-startup.  Used to
+            assert the startup ordering required by issue #788.
     """
     import enum
 
@@ -2892,6 +2897,16 @@ def _make_fake_meshcore_mod(
         async def ensure_contacts(self):
             if fail_ensure_contacts:
                 raise RuntimeError("contacts unavailable")
+            if on_ensure_contacts is not None:
+                # Yield once before populating so tests observing
+                # ``connected_event`` mid-startup can race the populate the
+                # same way the real meshcore library does — its
+                # ``ensure_contacts`` awaits multiple serial round-trips
+                # before contacts land in ``iface._contacts``.
+                import asyncio as _aio
+
+                await _aio.sleep(0)
+                on_ensure_contacts()
 
         async def start_auto_message_fetching(self):
             pass
@@ -3108,6 +3123,70 @@ def test_run_meshcore_ensure_contacts_failure_continues(monkeypatch):
     assert connected_event.is_set()
     assert error_holder[0] is None
     assert "warning" in logged
+
+
+def test_run_meshcore_signals_connected_only_after_ensure_contacts(monkeypatch):
+    """Regression for issue #788: contacts must be populated before connected_event fires.
+
+    The MeshCore initial snapshot in :func:`daemon._try_send_snapshot` runs as
+    soon as :func:`MeshcoreProvider.connect` returns, which itself returns as
+    soon as ``connected_event`` is set.  If ``connected_event`` is signalled
+    before ``ensure_contacts()`` finishes populating ``iface._contacts``, the
+    first snapshot is empty and ``state.initial_snapshot_sent`` is never set
+    to ``True`` (daemon.py:428), so known contacts never get upserted.
+
+    This test drives :func:`_run_meshcore` with a fake ``ensure_contacts``
+    that injects a contact into the interface, then records the contact
+    snapshot at the precise moment ``connected_event`` is observed.  The
+    snapshot must already contain the contact.
+    """
+    import asyncio
+    import threading
+    import data.mesh_ingestor.protocols.meshcore as _mod
+
+    monkeypatch.setattr(_mod.config, "_debug_log", lambda *_a, **_k: None)
+
+    iface = _MeshcoreInterface(target=None)
+    pub_key = "aabbccdd" + "00" * 28
+
+    def _populate_contacts() -> None:
+        iface._update_contact(
+            {"public_key": pub_key, "adv_name": "Repeater", "last_advert": 1000}
+        )
+
+    fake_mod = _make_fake_meshcore_mod(on_ensure_contacts=_populate_contacts)
+    _patch_meshcore_mod(monkeypatch, _mod, fake_mod)
+
+    snapshot_at_signal: list = []
+
+    async def _runner() -> None:
+        connected_event = threading.Event()
+        error_holder: list = [None]
+        task = asyncio.create_task(
+            _mod._run_meshcore(iface, "/dev/ttyUSB0", connected_event, error_holder)
+        )
+        # Spin until the runner signals readiness, then immediately capture
+        # the contact snapshot — this is the exact moment the daemon would
+        # call _try_send_snapshot() in production.
+        for _ in range(500):
+            await asyncio.sleep(0)
+            if connected_event.is_set():
+                snapshot_at_signal.extend(iface.contacts_snapshot())
+                break
+        assert iface._stop_event is not None
+        iface._stop_event.set()
+        await task
+        assert error_holder[0] is None
+        assert connected_event.is_set()
+
+    asyncio.run(_runner())
+
+    assert snapshot_at_signal, (
+        "connected_event must not fire before ensure_contacts() populates "
+        "iface._contacts (issue #788)"
+    )
+    node_ids = {nid for nid, _ in snapshot_at_signal}
+    assert "!aabbccdd" in node_ids
 
 
 def test_run_meshcore_ensure_channel_names_failure_continues(monkeypatch):


### PR DESCRIPTION
Fix #788

