### PR TITLE
harden: should not use md5 to generate hashes in api_cache.rb...

### DIFF
--- a/web/lib/potato_mesh/application/api_cache.rb
+++ b/web/lib/potato_mesh/application/api_cache.rb
@@ -83,7 +83,7 @@ module PotatoMesh
           end
 
           value = yield
-          etag = Digest::MD5.hexdigest(value)
+          etag = Digest::SHA256.hexdigest(value)
 
           @mutex.synchronize do
             evict_oldest_if_full


### PR DESCRIPTION
## Summary
Harden input handling in `web/lib/potato_mesh/application/api_cache.rb` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | ruby.lang.security.weak-hashes-md5.weak-hashes-md5 |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `ruby.lang.security.weak-hashes-md5.weak-hashes-md5` |
| **File** | `web/lib/potato_mesh/application/api_cache.rb:86` |
| **Assessment** | Defensive hardening |

**Description**: Should not use md5 to generate hashes. md5 is proven to be vulnerable through the use of brute-force attacks. Could also result in collisions, leading to potential collision attacks. Use SHA256 or other hashing functions instead.

## Threat Model Context

This is a containerized service - vulnerabilities may be exploitable depending on network exposure.

## Changes
- `web/lib/potato_mesh/application/api_cache.rb`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
