### PR TITLE
docs: correct .env.example's reticulum node id derivation (RE8)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,11 +44,15 @@ PROTOCOL="meshtastic"
 # network. Empty is the default.
 # RETICULUM_INTERFACES="rnode"
 
-# INGESTOR_NODE_ID (see below) is an OVERRIDE here, not a requirement. Reticulum
-# has no handshake revealing "our" node id, so the ingestor owns an RNS identity
-# of its own: it derives its !xxxxxxxx from the transport identity already in
-# RETICULUM_CONFIG_DIR, so the heartbeat and the packets/hour stats come up
-# unaided. Set INGESTOR_NODE_ID only to override that.
+# INGESTOR_NODE_ID (see below) is an OVERRIDE here, not a requirement. The
+# ingestor derives its !xxxxxxxx from your primary identity -- the one announcing
+# the most destinations on this machine -- so the heartbeat and the packets/hour
+# stats come up unaided. It is not the transport identity. Set INGESTOR_NODE_ID
+# to override the pick, or where no one identity announces the most.
+#
+# Changing the id strands the old row: the previous ingestor stays in
+# /api/ingestors without heartbeats until it ages out. Leaving the variable
+# as-is across upgrades is inert.
 #
 # CONNECTION does not apply. It names one serial/TCP/BLE endpoint, which an RNS
 # stack of many interfaces does not have. Its counterparts are the two variables
@@ -215,7 +219,7 @@ POTATOMESH_IMAGE_TAG="latest"
 # Host node id used for the ingestor heartbeat. REQUIRED for TRANSPORT=udp, which
 # cannot auto-detect "self" -- without it the heartbeat never registers and the
 # packets/hour stats stay at zero. OPTIONAL for PROTOCOL=reticulum, which derives
-# its own id from the identity it owns; set it there only to override that.
+# its own id from your primary identity; set it there only to override that.
 # INGESTOR_NODE_ID=!xxxxxxxx
 
 # Multicast group/port for "Mesh via UDP" (defaults shown).

--- a/tests/test_reticulum_unit.py
+++ b/tests/test_reticulum_unit.py
@@ -1573,6 +1573,39 @@ class TestReticulumDeploymentSurface:
                 re.MULTILINE | re.IGNORECASE,
             ), f"{name} still presents INGESTOR_NODE_ID as required for reticulum"
 
+    def test_docs_do_not_key_the_ingestor_on_the_transport_identity(self):
+        """RE8 excludes the transport identity from the pick; docs must agree.
+
+        RNS generates the transport identity as an independent keypair, so it
+        matches none of the operator's announced destinations -- keying on it
+        registered a node id the operator could not recognise.  A doc still
+        naming it would send them looking for the wrong hash in ``rnstatus``.
+        """
+        for name in ("README.md", ".env.example"):
+            text = (REPO_ROOT / name).read_text(encoding="utf-8")
+            assert (
+                "from the transport identity" not in text
+            ), f"{name} still derives the ingestor node id from the transport identity"
+            assert re.search(
+                r"primary identity", text, re.IGNORECASE
+            ), f"{name} does not name the primary identity as the id's source"
+
+    def test_docs_warn_that_changing_the_id_strands_the_old_row(self):
+        """Moving the id leaves a heartbeat-less row behind, so operators are told.
+
+        Nothing in code warns: that would need a durable record of the
+        previously registered id, which this provider does not keep.  The
+        operator-facing docs are the only place the caveat can live.
+        """
+        for name in ("README.md", ".env.example"):
+            text = (REPO_ROOT / name).read_text(encoding="utf-8")
+            assert re.search(
+                r"strands? the old row", text, re.IGNORECASE
+            ), f"{name} does not warn that changing the id strands the old row"
+            assert re.search(
+                r"ages out", text, re.IGNORECASE
+            ), f"{name} does not say the stranded row ages out"
+
     def test_docs_state_that_connection_does_not_apply(self):
         """RN10's answer has to reach the operator, not just the log."""
         for name in ("README.md", ".env.example"):


### PR DESCRIPTION
`.env.example` still described the #896 model — the ingestor owning an RNS identity and deriving its `!xxxxxxxx` from "the transport identity already in `RETICULUM_CONFIG_DIR`".

#897 shipped the opposite. SPEC RE8 excludes the transport identity from the pick, because RNS generates it as an independent keypair that matches none of the operator's announced destinations — keying on it registered `!fbf8e338` for a host whose primary identity was `27716218…`. The id is the discovered primary identity, the one announcing the most destinations on the machine.

`README.md` says this correctly ("It is **not** the transport identity, and not the hash `rnstatus` prints as 'Transport Instance'"). `.env.example` contradicted it in both places it mentions the derivation, and an operator setting the variable reads `.env.example`, not the README.

Also carries over the **strands the old row** caveat #897 added to `README.md` and `CHANGELOG.md`, since `.env.example` is where an operator is standing when they set the variable that moves the id.

Docs only — no behavior change.

## Tests

Two guards added to `TestReticulumDeploymentSurface`, both negative-tested against `main` where they correctly fail:

- `test_docs_do_not_key_the_ingestor_on_the_transport_identity` — README and `.env.example` must not derive the id "from the transport identity", and must name the primary identity.
- `test_docs_warn_that_changing_the_id_strands_the_old_row`

```
$ python -m pytest -q
1443 passed, 1 warning in 35.05s

$ black --check tests/ data/
All done! ✨ 🍰 ✨
91 files would be left unchanged.
```

https://claude.ai/code/session_01F8MHsE7xT4BhcQxPJf2AUR